### PR TITLE
fix: Removed deprecated eslint rule

### DIFF
--- a/docs/postcss/default.md
+++ b/docs/postcss/default.md
@@ -41,6 +41,9 @@ Here's a couple of ideas to move away from PostCSS:
 
 The shared configuration offered by `@workleap/postcss-configs` includes the following features:
 
+### Preset Env
+
+- [Stage 3](https://preset-env.cssdb.org/features/#stage-3)
 - [Autoprefixer](https://github.com/postcss/autoprefixer)
 
 ## Getting started

--- a/packages/eslint-plugin/lib/config/typescript.ts
+++ b/packages/eslint-plugin/lib/config/typescript.ts
@@ -17,7 +17,6 @@ const config: Linter.Config = {
 
                 // additional rules we want
                 "@typescript-eslint/consistent-type-definitions": "warn",
-                "@typescript-eslint/no-implicit-any-catch": "warn",
                 "@typescript-eslint/explicit-member-accessibility": ["warn", { accessibility: "no-public" }],
                 "@typescript-eslint/method-signature-style": "warn",
                 "comma-dangle":"off",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,14 +491,14 @@ importers:
         specifier: 5.0.4
         version: 5.0.4
       webpack:
-        specifier: 5.86.0
-        version: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
+        specifier: 5.88.2
+        version: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: 5.1.4
-        version: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
+        version: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
       webpack-dev-server:
-        specifier: 4.15.0
-        version: 4.15.0(webpack-cli@5.1.4)(webpack@5.86.0)
+        specifier: 4.15.1
+        version: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.2)
 
   sample/components:
     devDependencies:
@@ -4352,7 +4352,7 @@ packages:
     dependencies:
       '@types/node': 20.3.2
       tapable: 2.2.1
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -4762,29 +4762,29 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@xtuc/long': 4.2.2
 
-  /@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.86.0):
+  /@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.88.2):
     resolution: {integrity: sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.86.0):
+  /@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.88.2):
     resolution: {integrity: sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
     dev: true
 
-  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.0)(webpack@5.86.0):
+  /@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.88.2):
     resolution: {integrity: sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
@@ -4795,9 +4795,9 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
-      webpack-dev-server: 4.15.0(webpack-cli@5.1.4)(webpack@5.86.0)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.2)
     dev: true
 
   /@xmldom/xmldom@0.8.8:
@@ -6243,6 +6243,14 @@ packages:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  /enhanced-resolve@5.15.0:
+    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.1
+    dev: true
 
   /enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -11739,7 +11747,7 @@ packages:
       terser: 5.17.7
       webpack: 5.86.0(@swc/core@1.3.66)(esbuild@0.17.17)
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.66)(webpack@5.86.0):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.66)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -11761,7 +11769,7 @@ packages:
       schema-utils: 3.2.0
       serialize-javascript: 6.0.1
       terser: 5.17.7
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
     dev: true
 
   /terser@5.17.7:
@@ -12657,7 +12665,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /webpack-cli@5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0):
+  /webpack-cli@5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2):
     resolution: {integrity: sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==}
     engines: {node: '>=14.15.0'}
     hasBin: true
@@ -12675,9 +12683,9 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.86.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.86.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.0)(webpack@5.86.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.88.2)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.1)(webpack@5.88.2)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -12686,8 +12694,8 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
-      webpack-dev-server: 4.15.0(webpack-cli@5.1.4)(webpack@5.86.0)
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.2)
       webpack-merge: 5.9.0
     dev: true
 
@@ -12705,56 +12713,18 @@ packages:
       webpack: 5.86.0(@swc/core@1.3.66)(esbuild@0.17.17)
     dev: true
 
-  /webpack-dev-server@4.15.0(webpack-cli@5.1.4)(webpack@5.86.0):
-    resolution: {integrity: sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==}
+  /webpack-dev-middleware@5.3.3(webpack@5.88.2):
+    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
-    hasBin: true
     peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-      webpack-cli:
-        optional: true
+      webpack: ^4.0.0 || ^5.0.0
     dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.5.0
-      '@types/express': 4.17.17
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.1
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.5
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.1.1
-      chokidar: 3.5.3
       colorette: 2.0.20
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.2
-      graceful-fs: 4.2.11
-      html-entities: 2.3.5
-      http-proxy-middleware: 2.0.6(@types/express@4.17.17)
-      ipaddr.js: 2.1.0
-      launch-editor: 2.6.0
-      open: 8.4.2
-      p-retry: 4.6.2
-      rimraf: 3.0.2
+      memfs: 3.5.3
+      mime-types: 2.1.35
+      range-parser: 1.2.1
       schema-utils: 4.1.0
-      selfsigned: 2.1.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack: 5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
-      webpack-dev-middleware: 5.3.3(webpack@5.86.0)
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
     dev: true
 
   /webpack-dev-server@4.15.0(webpack@5.86.0):
@@ -12800,6 +12770,58 @@ packages:
       spdy: 4.0.2
       webpack: 5.86.0(@swc/core@1.3.66)(esbuild@0.17.17)
       webpack-dev-middleware: 5.3.3(webpack@5.86.0)
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+    dev: true
+
+  /webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.88.2):
+    resolution: {integrity: sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==}
+    engines: {node: '>= 12.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.37.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/bonjour': 3.5.10
+      '@types/connect-history-api-fallback': 1.5.0
+      '@types/express': 4.17.17
+      '@types/serve-index': 1.9.1
+      '@types/serve-static': 1.15.1
+      '@types/sockjs': 0.3.33
+      '@types/ws': 8.5.5
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.1.1
+      chokidar: 3.5.3
+      colorette: 2.0.20
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.18.2
+      graceful-fs: 4.2.11
+      html-entities: 2.3.5
+      http-proxy-middleware: 2.0.6(@types/express@4.17.17)
+      ipaddr.js: 2.1.0
+      launch-editor: 2.6.0
+      open: 8.4.2
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.1.0
+      selfsigned: 2.1.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack: 5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4)
+      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
+      webpack-dev-middleware: 5.3.3(webpack@5.88.2)
       ws: 8.13.0
     transitivePeerDependencies:
       - bufferutil
@@ -12859,8 +12881,8 @@ packages:
       - esbuild
       - uglify-js
 
-  /webpack@5.86.0(@swc/core@1.3.66)(webpack-cli@5.1.4):
-    resolution: {integrity: sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==}
+  /webpack@5.88.2(@swc/core@1.3.66)(webpack-cli@5.1.4):
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -12878,7 +12900,7 @@ packages:
       acorn-import-assertions: 1.9.0(acorn@8.8.2)
       browserslist: 4.21.7
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.14.1
+      enhanced-resolve: 5.15.0
       es-module-lexer: 1.2.1
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -12890,9 +12912,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.2.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.66)(webpack@5.86.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.66)(webpack@5.88.2)
       watchpack: 2.4.0
-      webpack-cli: 5.1.4(webpack-dev-server@4.15.0)(webpack@5.86.0)
+      webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'

--- a/sample/app/package.json
+++ b/sample/app/package.json
@@ -43,9 +43,9 @@
         "postcss": "8.4.24",
         "ts-jest": "29.1.0",
         "typescript": "5.0.4",
-        "webpack": "5.86.0",
+        "webpack": "5.88.2",
         "webpack-cli": "5.1.4",
-        "webpack-dev-server": "4.15.0",
+        "webpack-dev-server": "4.15.1",
         "postcss-preset-env": "8.5.1"
     },
     "dependencies": {


### PR DESCRIPTION
ESLint `@typescript-eslint/no-implicit-any-catch` hasd been deprecated and remove from `@typescript-eslint`. Is it causing errors in the shared configurations consumer projects.