### PR TITLE
fix: swc targets

### DIFF
--- a/docs/default.md
+++ b/docs/default.md
@@ -51,6 +51,10 @@ We hope that introducing CLI with a collection of configuration libraries will f
 
 While developing the configuration libraries, we kept one guiding principle in mind, **no locked in** :heart::v:. We truly hope that the default configurations will satisfy your application needs, but if it doesn't, there will always be an easy way to extend or override the default configuration.
 
+## Target environment
+
+The majority of the shared tooling configurations targets [ESM](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) and the latest [ECMAScript](https://en.wikipedia.org/wiki/ECMAScript) version (ESNext). If you are in the process of migrating an existing project to `workleap/web-configs`, and would rather delay transitioning to ESM, have a look at the _Target environment_ section of each tool for additional information about how to support **non ESM compliant** solutions.
+
 ## Supported tools
 
 | Name | NPM | Documentation |

--- a/docs/eslint/default.md
+++ b/docs/eslint/default.md
@@ -51,14 +51,17 @@ This way, it's pretty straightforward for the consumer to configure ESLint as it
 | :icon-mark-github: [typescript-library](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/eslint-plugin/lib/config/by-project-type/typescript-library.ts){ target="_blank" } | For TypeScript libraries developed **without** [React](https://react.dev/). |
 | :icon-mark-github: [monorepo-workspace](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/eslint-plugin/lib/config/by-project-type/monorepo-workspace.ts){ target="_blank" } | For the workspace configuration of a monorepo solution. |
 
+### Target environment
+
+The provided shared configurations targets the following environment:
+
+- ESM / CommonJS
+- ESNext
+- Node
+
 ## Prettier
 
 For a complete explanation of why we chose to stick with [ESLint](https://eslint.org/) for stylistic rules rather than migrating to [Prettier](https://prettier.io/), read the following [article](https://antfu.me/posts/why-not-prettier).
-
-## Target environment
-
-- ESM
-- ESNext
 
 ## Getting started
 

--- a/docs/postcss/default.md
+++ b/docs/postcss/default.md
@@ -26,7 +26,7 @@ npm create @workleap/project@latest <output-directory>
 +++
 !!!
 
-## A word of caution
+## Deprecation warning
 
 As we actively work on improving our build time and **minimize** the number of tools **compiling/transpiling** frontend code, we expect [PostCSS](https://postcss.org/) to be one of the first tools that we will **deprecate** from our technology stack. Therefore, before adding PostCSS to your project, make sure that you really need it.
 

--- a/docs/swc/configure-build.md
+++ b/docs/swc/configure-build.md
@@ -41,24 +41,63 @@ web-project
 
 Then, open the newly created file and export the [SWC](https://swc.rs/) configuration by using the `defineBuildConfig(options)` function:
 
-```js !#6-8 swc.build.js
+```js !#6 swc.build.js
 // @ts-check
 
-import { defineBuildConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
 
 export default defineBuildConfig({
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 
-### `browsers`
+### `targets`
 
-In the previous code sample, the `defineBuildConfig(options)` function receives a [Browserslist](https://browsersl.ist/) configuration object through the mandatory `browsers` option.
+In the previous code sample, the `defineBuildConfig(options)` function receives a list of **minimal browser versions to support** through the mandatory `targets` option.
 
-The expected behavior would be for [SWC](https://swc.rs/) to load the supported browser versions from the closest `.browserslistrc` [configuration file](https://github.com/browserslist/browserslist#browserslistrc), but there is currently an [issue](https://github.com/swc-project/swc/issues/3365) preventing SWC from doing so when the `.browserslistrc` configuration is extended by a shared configuration from a package.
+The expected behavior for the supported browsers would be for [SWC](https://swc.rs/) to automatically load the minimal browser versions from the closest `.browserslistrc` [configuration file](https://github.com/browserslist/browserslist#browserslistrc). However, there is currently an [issue](https://github.com/swc-project/swc/issues/3365) preventing SWC from doing so when the configuration file include a query referencing an external [Browserslist](https://browsersl.ist/) configuration:
 
-Therefore, `@workleap/swc-configs` choosed to **delegate** the loading of the Browserslist configuration **to the consumer** by making the `browsers` option required.
+```.browserslistrc
+extends @workleap/browserslist-config
+```
+
+Therefore, `@workleap/swc-configs` has chosen to **delegate** the loading of the Browserslist configuration **to the consumer** by making the `targets` option required.
+
+### `browserslistToSwc`
+
+To help consumers provide SWC [targets](https://swc.rs/docs/configuration/supported-browsers#targets) from a [Browserslist](https://browsersl.ist/) configuration, `@workleap/swc-configs` offers the `browserslistToSwc(options)` utility function.
+
+This function can either transform an array of Browserslist [queries](https://github.com/browserslist/browserslist#queries) to SWC targets:
+
+```js !#6 swc.dev.js
+// @ts-check
+
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
+
+export default defineBuildConfig({
+    targets: browserslistToSwc({ queries: ["extends @workleap/browserslist-config"] })
+});
+```
+
+Or load the closest `.browserslistrc` configuration file and convert the queries into SWC targets:
+
+```.browserslistrc
+extends @workleap/browserslist-config
+```
+
+```js !#6 swc.build.js
+// @ts-check
+
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
+
+export default defineBuildConfig({
+    targets: browserslistToSwc()
+});
+```
+
+The `browserslistToSwc(options)` utility function accepts any option supported by Browserslist [JS API](https://github.com/browserslist/browserslist#js-api) in addition to a `queries` option:
+
+- `queries`: `string | string[]`
 
 ## 3. Set predefined options
 
@@ -69,15 +108,14 @@ Therefore, `@workleap/swc-configs` choosed to **delegate** the loading of the Br
 
 Whether SWC should expect to parse JavaScript or [TypeScript](https://www.typescriptlang.org/) code.
 
-```js !#7 swc.build.js
+```js !#6 swc.build.js
 // @ts-check
 
-import { defineBuildConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
 
 export default defineBuildConfig({
     parser: "ecmascript",
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 
@@ -100,11 +138,10 @@ To view the default development configuration of `@workleap/swc-configs`, have a
 transformer(config: SwcConfig, context: SwcConfigTransformerContext) => SwcConfig
 ```
 
-```js !#13 swc.build.js
+```js !#12 swc.build.js
 // @ts-check
 
-import { defineBuildConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
 
 function mangleMinifiedCode(config) {
         config.jsc.minify.mangle = true;
@@ -114,7 +151,7 @@ function mangleMinifiedCode(config) {
 
 export default defineBuildConfig({
     transformers: [mangleMinifiedCode],
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 

--- a/docs/swc/configure-build.md
+++ b/docs/swc/configure-build.md
@@ -103,14 +103,14 @@ transformer(config: SwcConfig, context: SwcConfigTransformerContext) => SwcConfi
 ```js !#13 swc.build.js
 // @ts-check
 
-import { defineBuildConfig, SwcConfigTransformer, SwcConfig } from "@workleap/swc-configs";
+import { defineBuildConfig } from "@workleap/swc-configs";
 import browsers from "@workleap/browserslist-config";
 
-const mangleMinifiedCode: SwcConfigTransformer = (config: SwcConfig) => {
-    config.jsc.minify.mangle = true;
+function mangleMinifiedCode(config) {
+        config.jsc.minify.mangle = true;
 
     return config;
-};
+}
 
 export default defineBuildConfig({
     transformers: [mangleMinifiedCode],

--- a/docs/swc/configure-dev.md
+++ b/docs/swc/configure-dev.md
@@ -124,14 +124,14 @@ transformer(config: SwcConfig, context: SwcConfigTransformerContext) => SwcConfi
 ```js !#13 swc.dev.js
 // @ts-check
 
-import { defineDevConfig, SwcConfigTransformer, SwcConfig } from "@workleap/swc-configs";
+import { defineDevConfig } from "@workleap/swc-configs";
 import browsers from "@workleap/browserslist-config";
 
-const disableReactBuiltins: SwcConfigTransformer = (config: SwcConfig) => {
+function disableReactBuiltins(config) {
     config.jsc.transform.react.useBuiltins = false;
 
     return config;
-};
+}
 
 export default defineDevConfig({
     transformers: [disableReactBuiltins],

--- a/docs/swc/configure-dev.md
+++ b/docs/swc/configure-dev.md
@@ -41,24 +41,63 @@ web-project
 
 Then, open the newly created file and export the [SWC](https://swc.rs/) configuration by using the `defineDevConfig(options)` function:
 
-```js !#6-8 swc.dev.js
+```js !#5-7 swc.dev.js
 // @ts-check
 
-import { defineDevConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
 
 export default defineDevConfig({
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 
-### `browsers`
+### `targets`
 
-In the previous code sample, the `defineDevConfig(options)` function receive a [Browserslist](https://browsersl.ist/) configuration object through the mandatory `browsers` option.
+In the previous code sample, the `defineDevConfig(options)` function receives a list of **minimal browser versions to support** through the mandatory `targets` option.
 
-The expected behavior would be for [SWC](https://swc.rs/) to load the supported browser versions from the closest `.browserslistrc` [configuration file](https://github.com/browserslist/browserslist#browserslistrc), but there is currently an [issue](https://github.com/swc-project/swc/issues/3365) preventing SWC from doing so when the `.browserslistrc` configuration is extended by a shared configuration from a package.
+The expected behavior for the supported browsers would be for [SWC](https://swc.rs/) to automatically load the minimal browser versions from the closest `.browserslistrc` [configuration file](https://github.com/browserslist/browserslist#browserslistrc). However, there is currently an [issue](https://github.com/swc-project/swc/issues/3365) preventing SWC from doing so when the configuration file include a query referencing an external [Browserslist](https://browsersl.ist/) configuration:
 
-Therefore, `@workleap/swc-configs` choosed to **delegate** the loading of the Browserslist configuration **to the consumer** by making the `browsers` option required.
+```.browserslistrc
+extends @workleap/browserslist-config
+```
+
+Therefore, `@workleap/swc-configs` has chosen to **delegate** the loading of the Browserslist configuration **to the consumer** by making the `targets` option required.
+
+### `browserslistToSwc`
+
+To help consumers provide SWC [targets](https://swc.rs/docs/configuration/supported-browsers#targets) from a [Browserslist](https://browsersl.ist/) configuration, `@workleap/swc-configs` offers the `browserslistToSwc(options)` utility function.
+
+This function can either transform an array of Browserslist [queries](https://github.com/browserslist/browserslist#queries) to SWC targets:
+
+```js !#6 swc.dev.js
+// @ts-check
+
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
+
+export default defineDevConfig({
+    targets: browserslistToSwc({ queries: ["extends @workleap/browserslist-config"] })
+});
+```
+
+Or load the closest `.browserslistrc` configuration file and convert the queries into SWC targets:
+
+```.browserslistrc
+extends @workleap/browserslist-config
+```
+
+```js !#6 swc.dev.js
+// @ts-check
+
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
+
+export default defineDevConfig({
+    targets: browserslistToSwc()
+});
+```
+
+The `browserslistToSwc(options)` utility function accepts any option supported by Browserslist [JS API](https://github.com/browserslist/browserslist#js-api) in addition to a `queries` option:
+
+- `queries`: `string | string[]`
 
 ## 3. Set predefined options
 
@@ -71,15 +110,14 @@ The `defineDevConfig(options)` function can be used as shown in the previous exa
 
 Whether or not to enable [Fast Refresh](https://www.npmjs.com/package/react-refresh).
 
-```js !#7 swc.dev.js
+```js !#6 swc.dev.js
 // @ts-check
 
-import { defineDevConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
 
 export default defineDevConfig({
     fastRefresh: true,
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 
@@ -90,15 +128,14 @@ export default defineDevConfig({
 
 Whether SWC should expect to parse JavaScript or [TypeScript](https://www.typescriptlang.org/) code.
 
-```js !#7 swc.dev.js
+```js !#6 swc.dev.js
 // @ts-check
 
-import { defineDevConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
 
 export default defineDevConfig({
     parser: "ecmascript",
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 
@@ -121,11 +158,10 @@ To view the default development configuration of `@workleap/swc-configs`, have a
 transformer(config: SwcConfig, context: SwcConfigTransformerContext) => SwcConfig
 ```
 
-```js !#13 swc.dev.js
+```js !#12 swc.dev.js
 // @ts-check
 
-import { defineDevConfig } from "@workleap/swc-configs";
-import browsers from "@workleap/browserslist-config";
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
 
 function disableReactBuiltins(config) {
     config.jsc.transform.react.useBuiltins = false;
@@ -135,7 +171,7 @@ function disableReactBuiltins(config) {
 
 export default defineDevConfig({
     transformers: [disableReactBuiltins],
-    browsers
+    targets: browserslistToSwc()
 });
 ```
 

--- a/docs/swc/default.md
+++ b/docs/swc/default.md
@@ -52,9 +52,9 @@ The shared configurations offered by `@workleap/swc-configs` includes the follow
 - ESM
 - ECMAScript features matching the provided `browsers`
 
-## A note about Rspack
+## Upcoming deprecations
 
-Somewhere in 2024, [we expect to migrate from webpack to Rspack](../webpack/default.md#a-note-about-rspack). Once the migration is completed, the SWC [development](configure-dev.md) and [production](configure-build.md) configurations will not be required anymore as [Rspack](https://www.rspack.dev/) offers out of the box support for [React](https://react.dev/) and [TypeScript](https://www.typescriptlang.org/). 
+Somewhere in 2024, [we expect to migrate from webpack to Rspack](../webpack/default.md#a-note-about-rspack). Once the migration is completed, the SWC [development](configure-dev.md) and [production](configure-build.md) configurations will not be used anymore as [Rspack](https://www.rspack.dev/) offers out of the box support for [React](https://react.dev/) and [TypeScript](https://www.typescriptlang.org/). 
 
 Still, the [Jest configuration](configure-jest.md) will continue to be available as there is no integration between Rspack and [Jest](https://jestjs.io/).
 

--- a/docs/swc/default.md
+++ b/docs/swc/default.md
@@ -26,12 +26,6 @@ npm create @workleap/project@latest <output-directory>
 +++
 !!!
 
-## A note about Rspack
-
-Somewhere in 2024, [we expect to migrate from webpack to Rspack](../webpack/default.md#a-note-about-rspack). Once the migration is completed, the SWC [development](configure-dev.md) and [production](configure-build.md) configurations will not be required anymore as [Rspack](https://www.rspack.dev/) offers out of the box support for [React](https://react.dev/) and [TypeScript](https://www.typescriptlang.org/). 
-
-Still, the [Jest configuration](configure-jest.md) will continue to be available as there is no integration between Rspack and [Jest](https://jestjs.io/).
-
 ## Features
 
 The shared configurations offered by `@workleap/swc-configs` includes the following features 👇
@@ -53,11 +47,17 @@ The shared configurations offered by `@workleap/swc-configs` includes the follow
 
 - Minification
 
-## Target environment
+### Target environment
 
 - ESM
-- ESNext
+- ECMAScript features matching the provided `browsers`
+
+## A note about Rspack
+
+Somewhere in 2024, [we expect to migrate from webpack to Rspack](../webpack/default.md#a-note-about-rspack). Once the migration is completed, the SWC [development](configure-dev.md) and [production](configure-build.md) configurations will not be required anymore as [Rspack](https://www.rspack.dev/) offers out of the box support for [React](https://react.dev/) and [TypeScript](https://www.typescriptlang.org/). 
+
+Still, the [Jest configuration](configure-jest.md) will continue to be available as there is no integration between Rspack and [Jest](https://jestjs.io/).
 
 ## Getting started
 
-To get started, follow the quick start guide to configure SWC for either a [development environment](configure-dev.md), a [production environment](configure-build.md) or to run [Jest environment](configure-jest.md).
+To get started, follow the quick start guide to configure SWC for either a [development environment](configure-dev.md), a [production environment](configure-build.md) or to run [Jest tests](configure-jest.md).

--- a/docs/tsup/default.md
+++ b/docs/tsup/default.md
@@ -49,7 +49,7 @@ The shared configurations offered by `@workleap/tsup-configs` includes the follo
 
 - Output to `/dist`
 
-## Target environment
+### Target environment
 
 - ESM
 - ESNext

--- a/docs/typescript/custom-configuration.md
+++ b/docs/typescript/custom-configuration.md
@@ -26,7 +26,11 @@ You can update a default rule value by defining the rule locally with its new va
 }
 ```
 
-## CommonJS
+<!-- I know commented code/text is bad, I will go back later to this in my next PR. The goal will be to provide a configuration for
+     project using the "import" keyword but without specifying file extensions.
+ -->
+
+<!-- ## CommonJS
 
 If you are migrating an existing project and prefer to wait before moving to ESM, add the following custom configurations:
 
@@ -36,6 +40,59 @@ If you are migrating an existing project and prefer to wait before moving to ESM
     "compilerOptions": {
         "module": "commonjs",
         "moduleResolution": "bundler"
+    }
+}
+``` -->
+
+## Monorepo support
+
+If you are developing a monorepo solution and need to reference projects within the solution, you'll need to add [compilerOptions](https://www.typescriptlang.org/tsconfig#compilerOptions) to the projects' `tsconfig.json` files.
+
+For example, given the following project structure:
+
+``` !#3,8,13
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├────── tsconfig.json
+├──── components (@sample/components)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├──── utils (@sample/utils)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├── package.json
+├── tsconfig.json
+```
+
+If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions`:
+
+```json packages/app/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/web-application.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/components": ["../components/index.ts"],
+            "@sample/utils": ["../utils/index.ts"]
+        }
+    }
+}
+```
+
+```json packages/components/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/utils": ["../utils/index.ts"]
+        }
     }
 }
 ```

--- a/docs/typescript/custom-configuration.md
+++ b/docs/typescript/custom-configuration.md
@@ -22,7 +22,8 @@ You can update a default rule value by defining the rule locally with its new va
     "extends": ["@workleap/typescript-configs/web-application"],
     "compilerOptions": {
         "strict": false
-    }
+    },
+    "exclude": ["dist", "node_modules"]
 }
 ```
 
@@ -46,7 +47,7 @@ If you are migrating an existing project and prefer to wait before moving to ESM
 
 ## Monorepo support
 
-If you are developing a monorepo solution and need to reference projects within the solution, you'll need to add [compilerOptions](https://www.typescriptlang.org/tsconfig#compilerOptions) to the projects' `tsconfig.json` files.
+If you are developing a monorepo solution and need to **reference projects within** the **solution**, you'll need to add [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#compilerOptions) to the projects' `tsconfig.json` files.
 
 For example, given the following project structure:
 
@@ -72,9 +73,9 @@ workspace
 ├── tsconfig.json
 ```
 
-If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions`:
+If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions.paths`:
 
-```json packages/app/tsconfig.json
+```json !#4-7 packages/app/tsconfig.json
 {
     "extends": "@workleap/typescript-configs/web-application.json",
     "compilerOptions": {
@@ -82,18 +83,20 @@ If the `packages/components` project is referencing the `packages/utils` project
             "@sample/components": ["../components/index.ts"],
             "@sample/utils": ["../utils/index.ts"]
         }
-    }
+    },
+    "exclude": ["dist", "node_modules"]
 }
 ```
 
-```json packages/components/tsconfig.json
+```json !#4-6 packages/components/tsconfig.json
 {
     "extends": "@workleap/typescript-configs/library.json",
     "compilerOptions": {
         "paths": {
             "@sample/utils": ["../utils/index.ts"]
         }
-    }
+    },
+    "exclude": ["dist", "node_modules"]
 }
 ```
 

--- a/docs/typescript/default.md
+++ b/docs/typescript/default.md
@@ -48,10 +48,14 @@ The shared configurations offered by `@workleap/typescript-configs` exclusively 
 | :icon-mark-github: [library](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/typescript-configs/library.json){ target="_blank" } | For library project developed with or without [React](https://react.dev/). |
 | :icon-mark-github: [monorepo-workspace](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/typescript-configs/monorepo-workspace.json){ target="_blank" } | For the workspace configuration of a monorepo solution. |
 
-## Target environment
+### Target environment
+
+The provided shared configurations targets the following environment:
 
 - ESM
 - ESNext
+
+<!-- If you are in the process of migrating an existing project to `@workleap/typescript-configs`, and would rather delay transitioning to ESM, refer to the [custom configuration](custom-configuration.md#commonjs) page for information about how to support CommonJS. -->
 
 ## Getting started
 

--- a/docs/webpack/default.md
+++ b/docs/webpack/default.md
@@ -26,7 +26,7 @@ npm create @workleap/project@latest <output-directory>
 +++
 !!!
 
-## A note about Rspack
+## A word about Rspack
 
 [Rspack](https://www.rspack.dev/) is a partial rewrite of [webpack](https://webpack.js.org/) in [Rust](https://foundation.rust-lang.org/) and will most likely be its successor once it's features complete and stable. Our goal is to migrate to Rspack somewhere in 2024 when [Module Federation](https://module-federation.io/) support will be available.
 

--- a/docs/webpack/default.md
+++ b/docs/webpack/default.md
@@ -65,6 +65,10 @@ The shared configurations offered by `@workleap/webpack-configs` includes the fo
 - Minification
 - Output to `/dist`
 
+### Target environment
+
+As per the [PostCSS](../postcss/default.md) and [SWC](../swc/default.md) configurations
+
 ## Getting started
 
 To get started, follow the quick start guide to configure webpack for either a [development environment](configure-dev.md) or a [production environment](configure-build.md).

--- a/packages/eslint-plugin/lib/config/core.ts
+++ b/packages/eslint-plugin/lib/config/core.ts
@@ -10,7 +10,7 @@ const config: Linter.Config = {
         ecmaVersion: "latest"
     },
     env: {
-        es6: true,
+        es2024: true,
         node: true,
         commonjs: true
     },

--- a/packages/eslint-plugin/lib/config/jest.ts
+++ b/packages/eslint-plugin/lib/config/jest.ts
@@ -8,7 +8,7 @@ const config: Linter.Config = {
             files: [...testFiles, ...reactTestFiles],
             plugins: ["jest"],
             env: {
-                es6: true,
+                es2024: true,
                 node: true,
                 browser: true,
                 commonjs: true,

--- a/packages/eslint-plugin/lib/config/react.ts
+++ b/packages/eslint-plugin/lib/config/react.ts
@@ -16,7 +16,7 @@ const config: Linter.Config = {
                 }
             },
             env: {
-                es6: true,
+                es2024: true,
                 node: true,
                 browser: true,
                 commonjs: true

--- a/packages/swc-configs/package.json
+++ b/packages/swc-configs/package.json
@@ -37,6 +37,7 @@
         "@workleap/eslint-plugin": "workspace:*",
         "@workleap/tsup-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",
+        "browserslist": "4.21.10",
         "jest": "29.5.0",
         "ts-node": "10.9.1",
         "tsup": "6.7.0",
@@ -45,10 +46,14 @@
     "peerDependencies": {
         "@swc/core": "*",
         "@swc/helpers": "*",
-        "@swc/jest": "*"
+        "@swc/jest": "*",
+        "browserslist": "*"
     },
     "peerDependenciesMeta": {
         "@swc/jest": {
+            "optional": true
+        },
+        "browserslist": {
             "optional": true
         }
     },

--- a/packages/swc-configs/src/browserslistToSwc.ts
+++ b/packages/swc-configs/src/browserslistToSwc.ts
@@ -1,0 +1,150 @@
+// Inspired by https://github.com/marcofugaro/browserslist-to-esbuild/blob/main/src/index.js.
+//
+// This function exist because browserslist-rs (which is used under the hood by SWC) doesn't support browserslist "extends" syntax: https://github.com/browserslist/browserslist-rs#limitations.
+// Therefore, we must parse ourself the ".browserslistrc" file to extract the browser entries and transform them into valid SWC "env.targets".
+//
+// The function will convert an array of browserslist entries from:
+//
+// ['and_chr 115',   'and_ff 115',   'and_qq 13.1',
+// 'and_uc 15.5',   'android 115',  'baidu 13.18',
+// 'bb 10',         'bb 7',         'chrome 116',
+// 'chrome 115',    'chrome 114',   'chrome 113',
+// 'chrome 112',    'chrome 111',   'chrome 110',
+// 'chrome 109',    'chrome 108',   'chrome 107',
+// 'edge 115',      'edge 114',     'edge 113',
+// 'edge 112',      'edge 111',     'edge 110',
+// 'edge 109',      'edge 108',     'edge 107',
+// 'edge 106',      'firefox 116',  'firefox 115',
+// 'firefox 114',   'firefox 113',  'firefox 112',
+// 'firefox 111',   'firefox 110',  'firefox 109',
+// 'firefox 108',   'firefox 107',  'ie 11',
+// 'ie 10',         'ie 9',         'ie 8',
+// 'ie 7',          'ie 6',         'ie 5.5',
+// 'ie_mob 11',     'ie_mob 10',    'ios_saf 16.5',
+// 'ios_saf 16.4',  'ios_saf 16.3', 'ios_saf 16.2',
+// 'ios_saf 16.1',  'ios_saf 16.0', 'ios_saf 15.6-15.7',
+// 'ios_saf 15.5',  'ios_saf 15.4', 'ios_saf 15.2-15.3',
+// 'kaios 3.0-3.1', 'kaios 2.5',    'op_mini all',
+// 'op_mob 73',     'opera 101',    'opera 100',
+// 'opera 99',      'opera 98',     'opera 97',
+// 'opera 96',      'opera 95',     'opera 94',
+// 'opera 93',      'opera 92',     'safari 16.5',
+// 'safari 16.4',   'safari 16.3',  'safari 16.2',
+// 'safari 16.1',   'safari 16.0',  'safari 15.6',
+// 'safari 15.5',   'safari 15.4',  'safari 15.2-15.3',
+// 'samsung 21',    'samsung 20',   'samsung 19.0',
+// 'samsung 18.0',  'samsung 17.0', 'samsung 16.0',
+// 'samsung 15.0',  'samsung 14.0', 'samsung 13.0',
+// 'samsung 12.0']
+//
+// To an object literal of SWC "env.targets":
+//
+// {
+//  chrome: '107',
+//  firefox: '107',
+//  android: '115',
+//  edge: '106',
+//  ie: '5.5',
+//  opera: '73',
+//  safari: '15.2',
+//  samsung: '12'
+// }
+
+import browserslist from "browserslist";
+
+// Original browserslist-rs supported browsers (https://github.com/browserslist/browserslist-rs/blob/99a3244fc8c0e631a80a9cae5c41dca6c5a2aae5/build.rs#L10)
+// minus the browsers that are discarted by SWC (https://github.com/swc-project/swc/blob/main/crates/preset_env_base/src/lib.rs#L105).
+const SwcSupportedBrowsers = [
+    "ie",
+    "edge",
+    "firefox",
+    "chrome",
+    "safari",
+    "opera",
+    "ios_saf",
+    "android",
+    "op_mob",
+    "and_chr",
+    "and_ff",
+    "ie_mob",
+    "samsung"
+] as const;
+
+// SWC browsers mapping (https://github.com/swc-project/swc/blob/main/crates/preset_env_base/src/lib.rs#L90)
+const SwcBrowserMapping: Record<string, string> = {
+    "and_chr": "chrome",
+    "and_ff": "firefox",
+    "ie_mob": "ie",
+    "ios_saf": "ios",
+    "op_mob": "opera"
+};
+
+function parseBrowserslistEntry(entry: string) {
+    // "chrome 11" --> ["chrome", "11"]
+    const values = entry.split(" ");
+
+    let browser = values[0];
+    let version = values[1];
+
+    // "and_chr" --> "chrome"
+    if (SwcBrowserMapping[browser]) {
+        browser = SwcBrowserMapping[browser];
+    }
+
+    // "11.0-12.0" --> "11.0"
+    if (version.includes("-")) {
+        version = version.slice(0, version.indexOf("-"));
+    }
+
+    // "11.0" --> "11"
+    if (version.endsWith(".0")) {
+        version = version.slice(0, -2);
+    }
+
+    return {
+        browser,
+        version
+    };
+}
+
+export interface BrowserslistToSwcOptions extends Omit<browserslist.Options, "path"> {
+    queries?: string | string[];
+}
+
+export function browserslistToSwc(options: BrowserslistToSwcOptions = {}) {
+    const {
+        queries,
+        ...browserlistsOptions
+    } = options;
+
+    // Will return the entries matching the "queries" prop is provided, otherwise,
+    // will load the closest ".browserslistrc" file.
+    const entries = browserslist(queries, browserlistsOptions);
+
+    const targets = entries.reduce((acc, x: string) => {
+        const { browser, version } = parseBrowserslistEntry(x);
+
+        // Exclude browsers that are not supported by SWC.
+        if (((SwcSupportedBrowsers as unknown) as string[]).indexOf(browser) === -1) {
+            return acc;
+        }
+
+        // Let's make TS happy as we are now certain that the browser is part
+        // of the supported browsers list.
+        const _browser = browser as keyof typeof SwcSupportedBrowsers;
+
+        // SWC "env.targets" only support a single entry per target (browser).
+        // Therefore, we loop through the browser versions to keep only the oldest one.
+        if (acc[_browser]) {
+            if (parseFloat(acc[_browser]) > parseFloat(version)) {
+                acc[_browser] = version;
+            }
+        } else {
+            acc[_browser] = version;
+        }
+
+        return acc;
+    }, {} as Record<keyof typeof SwcSupportedBrowsers, string>);
+
+    return targets;
+}

--- a/packages/swc-configs/src/build.ts
+++ b/packages/swc-configs/src/build.ts
@@ -1,17 +1,15 @@
 import type { Config as SwcConfig } from "@swc/core";
-import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers";
+import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers.ts";
 
 export interface DefineBuildConfigOptions {
-    // Any is also used for SWC "targets" type.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    browsers: any;
+    targets: Record<string, string>;
     parser?: "ecmascript" | "typescript";
     transformers?: SwcConfigTransformer[];
 }
 
 export function defineBuildConfig(options: DefineBuildConfigOptions) {
     const {
-        browsers,
+        targets,
         parser = "typescript",
         transformers = []
     } = options;
@@ -53,8 +51,8 @@ export function defineBuildConfig(options: DefineBuildConfigOptions) {
             ignoreDynamic: true
         },
         env: {
-            // jsc.target is not provided because the provided browsers takes precedence.
-            targets: browsers
+            // jsc.target is not provided because the provided targets takes precedence.
+            targets
         }
     };
 

--- a/packages/swc-configs/src/build.ts
+++ b/packages/swc-configs/src/build.ts
@@ -27,8 +27,6 @@ export function defineBuildConfig(options: DefineBuildConfigOptions) {
                     syntax: "typescript",
                     tsx: true
                 },
-            // The output environment that the code will be compiled for.
-            target: "esnext",
             // View https://swc.rs/docs/configuration/minification for options.
             minify: {
                 compress: true,
@@ -55,6 +53,7 @@ export function defineBuildConfig(options: DefineBuildConfigOptions) {
             ignoreDynamic: true
         },
         env: {
+            // jsc.target is not provided because the provided browsers takes precedence.
             targets: browsers
         }
     };

--- a/packages/swc-configs/src/dev.ts
+++ b/packages/swc-configs/src/dev.ts
@@ -29,8 +29,6 @@ export function defineDevConfig(options: DefineDevConfigOptions) {
                     syntax: "typescript",
                     tsx: true
                 },
-            // The output environment that the code will be compiled for.
-            target: "esnext",
             transform: {
                 react: {
                 // Use "react/jsx-runtime".
@@ -55,6 +53,7 @@ export function defineDevConfig(options: DefineDevConfigOptions) {
             ignoreDynamic: true
         },
         env: {
+            // jsc.target is not provided because the provided browsers takes precedence.
             targets: browsers
         }
     };

--- a/packages/swc-configs/src/dev.ts
+++ b/packages/swc-configs/src/dev.ts
@@ -1,10 +1,8 @@
 import type { Config as SwcConfig } from "@swc/core";
-import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers";
+import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers.ts";
 
 export interface DefineDevConfigOptions {
-    // Any is also used for SWC "targets" type.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    browsers: any;
+    targets: Record<string, string>;
     fastRefresh?: boolean;
     parser?: "ecmascript" | "typescript";
     transformers?: SwcConfigTransformer[];
@@ -12,7 +10,7 @@ export interface DefineDevConfigOptions {
 
 export function defineDevConfig(options: DefineDevConfigOptions) {
     const {
-        browsers,
+        targets,
         fastRefresh = false,
         parser = "typescript",
         transformers = []
@@ -53,8 +51,8 @@ export function defineDevConfig(options: DefineDevConfigOptions) {
             ignoreDynamic: true
         },
         env: {
-            // jsc.target is not provided because the provided browsers takes precedence.
-            targets: browsers
+            // jsc.target is not provided because the provided targets takes precedence.
+            targets
         }
     };
 

--- a/packages/swc-configs/src/index.ts
+++ b/packages/swc-configs/src/index.ts
@@ -1,6 +1,7 @@
 import type { Config as SwcConfig } from "@swc/core";
 
 export type { SwcConfigTransformer, SwcConfigTransformerContext } from "./applyTransformers.ts";
+export * from "./browserslistToSwc.ts";
 export * from "./build.ts";
 export * from "./dev.ts";
 export * from "./jest.ts";

--- a/packages/swc-configs/src/jest.ts
+++ b/packages/swc-configs/src/jest.ts
@@ -1,5 +1,5 @@
 import type { Config as SwcConfig } from "@swc/core";
-import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers";
+import { applyTransformers, type SwcConfigTransformer } from "./applyTransformers.ts";
 
 export interface DefineJestConfigOptions {
     react?: boolean;

--- a/packages/swc-configs/tests/__snapshots__/browserslistToSwc.test.ts.snap
+++ b/packages/swc-configs/tests/__snapshots__/browserslistToSwc.test.ts.snap
@@ -1,0 +1,78 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser is a mobile alias for a desktop browser, and the mobile alias version is older than the oldest desktop browser version, use the alias version 1`] = `
+{
+  "chrome": "115",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser is a mobile alias to a desktop browser, include a target for the desktop browser 1`] = `
+{
+  "chrome": "115",
+  "firefox": "115",
+  "ie": "11",
+  "ios": "16.5",
+  "opera": "73",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser is not supported, do not include a target for the browser 1`] = `
+{
+  "firefox": "115",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser version has a 0 digit, remove the digit 1`] = `
+{
+  "samsung": "19",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser version has an non 0 digit, keep the digit 1`] = `
+{
+  "safari": "15.4",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser version is "all", keep "all" 1`] = `
+{
+  "chrome": "all",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when a browser version is a range, only keep the lower value of the range 1`] = `
+{
+  "safari": "15.2",
+}
+`;
+
+exports[`createSwcTargetsFromBrowserslistEntries when there are multiple versions of the same browser, only include the oldest version of the browser 1`] = `
+{
+  "android": "115",
+  "chrome": "107",
+  "edge": "113",
+  "firefox": "107",
+  "opera": "101",
+}
+`;
+
+exports[`when no queries are provided, load the closest .browserslistrc file 1`] = `
+{
+  "android": "116",
+  "chrome": "109",
+  "edge": "114",
+  "firefox": "102",
+  "ios": "16",
+  "opera": "73",
+  "safari": "15.6",
+  "samsung": "20",
+}
+`;
+
+exports[`when queries are provided, process the queries 1`] = `
+{
+  "chrome": "113",
+  "firefox": "107",
+  "ie": "11",
+}
+`;

--- a/packages/swc-configs/tests/browserslistToSwc.test.ts
+++ b/packages/swc-configs/tests/browserslistToSwc.test.ts
@@ -1,0 +1,105 @@
+import { browserslistToSwc, createSwcTargetsFromBrowserslistEntries } from "../src/browserslistToSwc.ts";
+
+describe("createSwcTargetsFromBrowserslistEntries", () => {
+    test("when a browser is not supported, do not include a target for the browser", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "and_uc 15.5",
+            "baidu 13.18",
+            "firefox 115"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser is a mobile alias to a desktop browser, include a target for the desktop browser", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "and_chr 115",
+            "and_ff 115",
+            "ie_mob 11",
+            "ios_saf 16.5",
+            "op_mob 73"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when there are multiple versions of the same browser, only include the oldest version of the browser", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "android 115",
+            "chrome 115",
+            "chrome 113",
+            "chrome 108",
+            "chrome 112",
+            "chrome 107",
+            "opera 101",
+            "chrome 111",
+            "chrome 110",
+            "chrome 109",
+            "chrome 114",
+            "edge 115",
+            "edge 114",
+            "edge 113",
+            "firefox 109",
+            "firefox 116",
+            "firefox 115",
+            "firefox 107",
+            "firefox 114",
+            "firefox 113",
+            "firefox 108",
+            "firefox 112",
+            "firefox 111",
+            "firefox 110"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser is a mobile alias for a desktop browser, and the mobile alias version is older than the oldest desktop browser version, use the alias version", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "and_chr 115",
+            "chrome 116"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser version is a range, only keep the lower value of the range", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "safari 15.2-15.3"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser version has a 0 digit, remove the digit", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "samsung 19.0"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser version has an non 0 digit, keep the digit", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "safari 15.4"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test("when a browser version is \"all\", keep \"all\"", () => {
+        const result = createSwcTargetsFromBrowserslistEntries([
+            "chrome all"
+        ]);
+
+        expect(result).toMatchSnapshot();
+    });
+});
+
+test("when queries are provided, use the queries", () => {
+    const result = browserslistToSwc({
+        queries: ["IE 11", "chrome 113", "firefox 107"]
+    });
+
+    expect(result).toMatchSnapshot();
+});

--- a/packages/tsup-configs/src/build.ts
+++ b/packages/tsup-configs/src/build.ts
@@ -1,5 +1,5 @@
 import type { Options as TsupConfig } from "tsup";
-import { applyTransformers, type TsupConfigTransformer } from "./applyTransformers";
+import { applyTransformers, type TsupConfigTransformer } from "./applyTransformers.ts";
 
 export interface DefineBuildConfigOptions extends TsupConfig {
     transformers?: TsupConfigTransformer[];

--- a/packages/tsup-configs/src/dev.ts
+++ b/packages/tsup-configs/src/dev.ts
@@ -1,5 +1,5 @@
 import type { Options as TsupConfig } from "tsup";
-import { applyTransformers, type TsupConfigTransformer } from "./applyTransformers";
+import { applyTransformers, type TsupConfigTransformer } from "./applyTransformers.ts";
 
 export interface DefineDevConfigOptions extends TsupConfig {
     transformers?: TsupConfigTransformer[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@workleap/typescript-configs':
         specifier: workspace:*
         version: link:../typescript-configs
+      browserslist:
+        specifier: 4.21.10
+        version: 4.21.10
       jest:
         specifier: 29.5.0
         version: 29.5.0(@types/node@20.3.2)(ts-node@10.9.1)
@@ -651,7 +654,7 @@ packages:
       '@babel/compat-data': 7.22.5
       '@babel/core': 7.21.4
       '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.7
+      browserslist: 4.21.10
       lru-cache: 5.1.1
       semver: 6.3.0
 
@@ -5060,8 +5063,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.21.7
-      caniuse-lite: 1.0.30001508
+      browserslist: 4.21.10
+      caniuse-lite: 1.0.30001524
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -5076,8 +5079,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.21.7
-      caniuse-lite: 1.0.30001508
+      browserslist: 4.21.10
+      caniuse-lite: 1.0.30001524
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -5302,6 +5305,16 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
+  /browserslist@4.21.10:
+    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001524
+      electron-to-chromium: 1.4.504
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.10)
+
   /browserslist@4.21.7:
     resolution: {integrity: sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -5311,16 +5324,18 @@ packages:
       electron-to-chromium: 1.4.427
       node-releases: 2.0.12
       update-browserslist-db: 1.0.11(browserslist@4.21.7)
+    dev: true
 
   /browserslist@4.21.9:
     resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001508
-      electron-to-chromium: 1.4.440
-      node-releases: 2.0.12
+      caniuse-lite: 1.0.30001524
+      electron-to-chromium: 1.4.504
+      node-releases: 2.0.13
       update-browserslist-db: 1.0.11(browserslist@4.21.9)
+    dev: false
 
   /bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
@@ -5404,9 +5419,10 @@ packages:
 
   /caniuse-lite@1.0.30001497:
     resolution: {integrity: sha512-I4/duVK4wL6rAK/aKZl3HXB4g+lIZvaT4VLAn2rCgJ38jVLb0lv2Xug6QuqmxXFVRJMF74SPPWPJ/1Sdm3vCzw==}
+    dev: true
 
-  /caniuse-lite@1.0.30001508:
-    resolution: {integrity: sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==}
+  /caniuse-lite@1.0.30001524:
+    resolution: {integrity: sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==}
 
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -5681,7 +5697,7 @@ packages:
   /core-js-compat@3.30.2:
     resolution: {integrity: sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==}
     dependencies:
-      browserslist: 4.21.7
+      browserslist: 4.21.10
     dev: true
 
   /core-js-pure@3.30.2:
@@ -6212,9 +6228,10 @@ packages:
 
   /electron-to-chromium@1.4.427:
     resolution: {integrity: sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==}
+    dev: true
 
-  /electron-to-chromium@1.4.440:
-    resolution: {integrity: sha512-r6dCgNpRhPwiWlxbHzZQ/d9swfPaEJGi8ekqRBwQYaR3WmA5VkqQfBWSDDjuJU1ntO+W9tHx8OHV/96Q8e0dVw==}
+  /electron-to-chromium@1.4.504:
+    resolution: {integrity: sha512-cSMwIAd8yUh54VwitVRVvHK66QqHWE39C3DRj8SWiXitEpVSY3wNPD9y1pxQtLIi4w3UdzF9klLsmuPshz09DQ==}
 
   /emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -9355,6 +9372,10 @@ packages:
 
   /node-releases@2.0.12:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
+    dev: true
+
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
 
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -10419,7 +10440,7 @@ packages:
       '@csstools/postcss-trigonometric-functions': 2.1.1(postcss@8.4.24)
       '@csstools/postcss-unset-value': 2.0.1(postcss@8.4.24)
       autoprefixer: 10.4.14(postcss@8.4.24)
-      browserslist: 4.21.9
+      browserslist: 4.21.10
       css-blank-pseudo: 5.0.2(postcss@8.4.24)
       css-has-pseudo: 5.0.2(postcss@8.4.24)
       css-prefers-color-scheme: 8.0.2(postcss@8.4.24)
@@ -12491,6 +12512,16 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /update-browserslist-db@1.0.11(browserslist@4.21.10):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.10
+      escalade: 3.1.1
+      picocolors: 1.0.0
+
   /update-browserslist-db@1.0.11(browserslist@4.21.7):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
@@ -12500,6 +12531,7 @@ packages:
       browserslist: 4.21.7
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.9):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
@@ -12510,6 +12542,7 @@ packages:
       browserslist: 4.21.9
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: false
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -12859,7 +12892,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.8.2
       acorn-import-assertions: 1.9.0(acorn@8.8.2)
-      browserslist: 4.21.7
+      browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.14.1
       es-module-lexer: 1.2.1
@@ -12898,7 +12931,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.8.2
       acorn-import-assertions: 1.9.0(acorn@8.8.2)
-      browserslist: 4.21.7
+      browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
       es-module-lexer: 1.2.1

--- a/sample/app/swc.build.js
+++ b/sample/app/swc.build.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-import browsers from "@workleap/browserslist-config";
-import { defineBuildConfig } from "@workleap/swc-configs";
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
 
 export const swcConfig = defineBuildConfig({
-    browsers
+    targets: browserslistToSwc()
 });

--- a/sample/app/swc.dev.js
+++ b/sample/app/swc.dev.js
@@ -1,8 +1,7 @@
 // @ts-check
 
-import browsers from "@workleap/browserslist-config";
-import { defineDevConfig } from "@workleap/swc-configs";
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
 
 export const swcConfig = defineDevConfig({
-    browsers
+    targets: browserslistToSwc()
 });


### PR DESCRIPTION
When using the SWC configuration, the browsers were not loaded correctly from the shared Browserslist configuration because it was providing an unsupported query as SWC `env.targets`.

To fix this, a new `browserslistToSwc` utility function as been added and the documentation as been updated accordingly.

Furthermore, the following changes has been made:

- Replaced SWC `browsers` option for `targets` options