### PR TITLE
fix: Disable TS check for JS files

### DIFF
--- a/docs/typescript/custom-configuration.md
+++ b/docs/typescript/custom-configuration.md
@@ -13,9 +13,9 @@ If you are in the process of **migrating an existing project** to use `@workleap
 For a list of the rules included with the default shared configurations, refer to the configuration files in the following [folder](https://github.com/gsoft-inc/wl-web-configs/tree/main/packages/typescript-configs) on GitHub.
 !!!
 
-## Change a default rule value
+## Change a default field value
 
-You can update a default rule value by defining the rule locally with its new value:
+You can update a default field value by defining the field locally with its new value:
 
 ```json !#3-5 tsconfig.json
 {
@@ -43,9 +43,9 @@ If you are **migrating** an existing project and prefer to wait before moving to
 
 ## Monorepo support
 
-If you are developing a monorepo solution and need to **reference projects within** the **solution**, you'll need to add [compilerOptions.paths](https://www.typescriptlang.org/tsconfig#compilerOptions) to the projects' `tsconfig.json` files.
+If you are developing a monorepo solution and need to **reference projects within** the **workspace**, you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) for every impacted project.
 
-For example, given the following project structure:
+Given the following workspace:
 
 ``` !#3,8,13
 workspace

--- a/packages/typescript-configs/core.json
+++ b/packages/typescript-configs/core.json
@@ -13,7 +13,8 @@
 
         "strict": true,
 
-        "checkJs": true,
+        "allowJs": true,
+        "checkJs": false,
 
         "esModuleInterop": true,
         "skipLibCheck": true,

--- a/retype.yml
+++ b/retype.yml
@@ -1,12 +1,14 @@
 input: ./docs
 output: .retype
 
+# Pro features
 poweredByRetype: false
 
 outbound:
     enabled: true
     icon: ""
 
+# Regular features
 edit:
     repo: "https://github.com/gsoft-inc/wl-web-configs"
     base: /docs


### PR DESCRIPTION
Disable TS check for JS files by setting in `core.ts`:

- `allowJs` to true
- `checkJs` to false

Before this change, it was impossible to include a JS file to a project without having an error whenever a type wasn't defined for a variable/argument.