### PR TITLE
docs: TS monorepo paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ When you are ready to release the packages, you must follow the following steps:
 1. Run `pnpm changeset` and follow the prompt. For versioning, always follow the [SemVer standard](https://semver.org/).
 2. Commit the newly generated file in your branch and submit a new Pull Request(PR). Changesets will automatically detect the changes and post a message in your pull request telling you that once the PR closes, the versions will be released.
 3. Find someone to review your PR.
-4. Merge the Pull request into `main`. A GitHub action will automatically trigger and update the version of the packages and publish them to [npm]https://www.npmjs.com/). A tag will also be created on GitHub tagging your PR merge commit.
+4. Merge the Pull request into `main`. A GitHub action will automatically trigger and update the version of the packages and publish them to [npm](https://www.npmjs.com/). A tag will also be created on GitHub tagging your PR merge commit.
 
 ### Troubleshooting
 
@@ -178,15 +178,15 @@ pnpm update-outdated-deps
 
 ## CI
 
-We use [GitHub Actions]() for this repository.
+We use [GitHub Actions](https://docs.github.com/en/actions) for this repository.
 
-The configuration is in the `.github/workflows` folder and the build results available [here](https://github.com/gsoft-inc/wl-web-configs/actions).
+You can find the configuration is in the `.github/workflows` folder and the build results are available [here](https://github.com/gsoft-inc/wl-web-configs/actions).
 
 We currently have 3 builds configured:
 
 ### Changesets
 
-This action run on a push on the `main` branch, and if theirs a file present in the `.changeset` folder, will publish the new package version on npm.
+This action runs on a push on the `main` branch. If there is a file present in the `.changeset` folder, it will publish the new package version on npm.
 
 ### CI
 

--- a/docs/typescript/custom-configuration.md
+++ b/docs/typescript/custom-configuration.md
@@ -41,61 +41,6 @@ If you are **migrating** an existing project and prefer to wait before moving to
 }
 ```
 
-## Monorepo support
-
-If you are developing a monorepo solution and need to **reference projects within** the **workspace**, you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) for every impacted project.
-
-Given the following workspace:
-
-``` !#3,8,13
-workspace
-├── packages
-├──── app
-├────── src
-├──────── ...
-├────── package.json
-├────── tsconfig.json
-├──── components (@sample/components)
-├────── src
-├──────── index.ts
-├────── package.json
-├────── tsconfig.json
-├──── utils (@sample/utils)
-├────── src
-├──────── index.ts
-├────── package.json
-├────── tsconfig.json
-├── package.json
-├── tsconfig.json
-```
-
-If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions.paths`:
-
-```json !#4-7 packages/app/tsconfig.json
-{
-    "extends": "@workleap/typescript-configs/web-application.json",
-    "compilerOptions": {
-        "paths": {
-            "@sample/components": ["../components/index.ts"],
-            "@sample/utils": ["../utils/index.ts"]
-        }
-    },
-    "exclude": ["dist", "node_modules"]
-}
-```
-
-```json !#4-6 packages/components/tsconfig.json
-{
-    "extends": "@workleap/typescript-configs/library.json",
-    "compilerOptions": {
-        "paths": {
-            "@sample/utils": ["../utils/index.ts"]
-        }
-    },
-    "exclude": ["dist", "node_modules"]
-}
-```
-
 ## Start from scratch
 
 If your situation is so challenging that you must start a new configuration from scratch, refer to the [advanced composition](advanced-composition.md) page.

--- a/docs/typescript/setup-monorepo.md
+++ b/docs/typescript/setup-monorepo.md
@@ -140,7 +140,7 @@ If you already have multiple projects in your monorepo solution, repeat the step
 
 ## 7. Customize configuration
 
-New projects shouldn't have to customize most the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
+New projects shouldn't have to customize most of the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
 
 ### Compiler paths
 

--- a/docs/typescript/setup-monorepo.md
+++ b/docs/typescript/setup-monorepo.md
@@ -144,7 +144,7 @@ New projects shouldn't have to customize most the default configurations offered
 
 ### Compiler paths
 
-If any projects of your solution are referencing other projects of the monorepo workspace, chances are that you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) in their `tsconfig.json` file.
+If any projects of your solution are referencing other projects of the monorepo workspace (e.g. `"@sample/components": "workspace:*"`), chances are that you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) in their `tsconfig.json` file.
 
 Given the following solution:
 

--- a/docs/typescript/setup-monorepo.md
+++ b/docs/typescript/setup-monorepo.md
@@ -140,7 +140,62 @@ If you already have multiple projects in your monorepo solution, repeat the step
 
 ## 7. Customize configuration
 
-New projects shouldn't have to customize the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
+New projects shouldn't have to customize most the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
+
+### Compiler paths
+
+If any projects of your solution are referencing other projects of the monorepo workspace, chances are that you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) in their `tsconfig.json` file.
+
+Given the following solution:
+
+``` !#3,8,13
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├────── tsconfig.json
+├──── components (@sample/components)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├──── utils (@sample/utils)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├── package.json
+├── tsconfig.json
+```
+
+If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions.paths`:
+
+```json !#4-7 packages/app/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/web-application.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/components": ["../components/index.ts"],
+            "@sample/utils": ["../utils/index.ts"]
+        }
+    },
+    "exclude": ["dist", "node_modules"]
+}
+```
+
+```json !#4-6 packages/components/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/utils": ["../utils/index.ts"]
+        }
+    },
+    "exclude": ["dist", "node_modules"]
+}
+```
 
 ## 8. Try it :rocket:
 


### PR DESCRIPTION
Moved the docs for TS `compilerOptions.paths` from the "Custom configuration" page to the "Monorepo setup" page.