### PR TITLE
fix: webpack-configs

### DIFF
--- a/docs/webpack/configure-build.md
+++ b/docs/webpack/configure-build.md
@@ -365,6 +365,7 @@ export const transformer: WebpackConfigTransformer = (config: WebpackConfig, con
 ```
 
 - `environment`: `"dev" | "build"`
+- `profile`: `boolean`
 
 ### Utilities
 
@@ -416,7 +417,7 @@ To make them accessible to the application files, webpack must be aware of those
 ### `environmentVariables`
 
 - **Type**: `Record<string, string | undefined>`
-- **Default**: `undefined`
+- **Default**: `{}`
 
 First, define the variables with `environmentVariables`:
 

--- a/docs/webpack/configure-dev.md
+++ b/docs/webpack/configure-dev.md
@@ -380,6 +380,7 @@ export const transformer: WebpackConfigTransformer = (config: WebpackConfig, con
 ```
 
 - `environment`: `"dev" | "build"`
+- `profile`: `boolean`
 
 ### Utilities
 
@@ -431,7 +432,7 @@ To make them accessible to the application files, webpack must be aware of those
 ### `environmentVariables`
 
 - **Type**: `Record<string, string | undefined>`
-- **Default**: `undefined`
+- **Default**: `{}`
 
 First, define the variables with `environmentVariables`:
 

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -76,7 +76,9 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
         miniCssExtractPluginOptions = defineMiniCssExtractPluginConfig(),
         minify = true,
         cssModules = false,
-        environmentVariables,
+        // Using an empty object literal as the default value to ensure
+        // "process.env" is always available.
+        environmentVariables = {},
         transformers = [],
         profile = false
     } = options;
@@ -101,7 +103,7 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
         },
         // Fixes caching for environmental variables using the DefinePlugin by forcing
         // webpack caching to prioritize hashes over timestamps.
-        snapshot: {
+        snapshot: cache ? {
             buildDependencies: {
                 hash: true,
                 timestamp: true
@@ -118,7 +120,7 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
                 hash: true,
                 timestamp: true
             }
-        },
+        } : undefined,
         optimization: minify
             ? {
                 minimize: true,
@@ -202,7 +204,8 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
     };
 
     const transformedConfig = applyTransformers(config, transformers, {
-        environment: "build"
+        environment: "build",
+        profile
     });
 
     return transformedConfig;

--- a/packages/webpack-configs/src/dev.ts
+++ b/packages/webpack-configs/src/dev.ts
@@ -91,7 +91,9 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
         htmlWebpackPlugin = defineDevHtmlWebpackPluginConfig(),
         fastRefresh = true,
         cssModules = false,
-        environmentVariables,
+        // Using an empty object literal as the default value to ensure
+        // "process.env" is always available.
+        environmentVariables = {},
         transformers = [],
         profile = false
     } = options;
@@ -125,7 +127,7 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
         },
         // Fixes caching for environmental variables using the DefinePlugin by forcing
         // webpack caching to prioritize hashes over timestamps.
-        snapshot: {
+        snapshot: cache ? {
             buildDependencies: {
                 hash: true,
                 timestamp: true
@@ -142,10 +144,12 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
                 hash: true,
                 timestamp: true
             }
-        },
+        } : undefined,
+        // See: https://webpack.js.org/guides/build-performance/#avoid-extra-optimization-steps
         optimization: {
-            // See: https://webpack.js.org/guides/build-performance/#avoid-extra-optimization-steps
-            runtimeChunk: true,
+            // Keep "runtimeChunk" to false, otherwise it breaks module federation
+            // (at least for the remote application).
+            runtimeChunk: false,
             removeAvailableModules: false,
             removeEmptyChunks: false,
             splitChunks: false
@@ -219,7 +223,8 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
     };
 
     const transformedConfig = applyTransformers(config, transformers, {
-        environment: "dev"
+        environment: "dev",
+        profile
     });
 
     return transformedConfig;

--- a/packages/webpack-configs/src/transformers/applyTransformers.ts
+++ b/packages/webpack-configs/src/transformers/applyTransformers.ts
@@ -2,10 +2,27 @@ import type { Configuration as WebpackConfig } from "webpack";
 
 export interface WebpackConfigTransformerContext {
     environment: "dev" | "build";
+    profile: boolean;
 }
 
 export type WebpackConfigTransformer = (config: WebpackConfig, context: WebpackConfigTransformerContext) => WebpackConfig;
 
 export function applyTransformers(config: WebpackConfig, transformers: WebpackConfigTransformer[], context: WebpackConfigTransformerContext) {
-    return transformers.reduce((acc, transformer) => transformer(acc, context), config);
+    let count = 0;
+
+    const transformedConfig = transformers.reduce((acc, transformer) => {
+        transformer(acc, context);
+
+        count += 1;
+
+        return acc;
+    }, config);
+
+    if (context.profile) {
+        if (count > 0) {
+            console.log(`[webpack-configs] Applied ${count} configuration transformers.`);
+        }
+    }
+
+    return transformedConfig;
 }

--- a/packages/webpack-configs/tests/dev.test.ts
+++ b/packages/webpack-configs/tests/dev.test.ts
@@ -281,7 +281,18 @@ test("transformers context environment is \"dev\"", () => {
         transformers: [mockTransformer]
     });
 
-    expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "dev" });
+    expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "dev", profile: false });
+});
+
+test("when the profile option is true, the transformers context profile value is \"true\"", () => {
+    const mockTransformer = jest.fn();
+
+    defineDevConfig(defineSwcConfig(Targets), {
+        profile: true,
+        transformers: [mockTransformer]
+    });
+
+    expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "dev", profile: true });
 });
 
 describe("defineDevHtmlWebpackPluginConfig", () => {


### PR DESCRIPTION
## Changes

### `@workleap/web-configs`

- `environmentVariables` default value is now `{}` to ensure `process.env` is always available.
- Added a `profile` prop to the transformers context object
- Disable the webpack config `snapshot` section if the `cache` option is false
- `optimization.runtimeChunk` is now `false` because it was breaking Module Federation

## Release

- Patch bump for `@workleap/web-configs`