### PR TITLE
fix: environment variables

### DIFF
--- a/docs/webpack/configure-build.md
+++ b/docs/webpack/configure-build.md
@@ -204,7 +204,7 @@ export default defineBuildConfig(swcConfig, {
 
 ### `htmlWebpackPlugin`
 
-- **Type**: `false` or an object literal accepting any `html-webpack-plugin` [option](https://github.com/jantimon/html-webpack-plugin#options)
+- **Type**: `boolean` or an object literal accepting any `html-webpack-plugin` [option](https://github.com/jantimon/html-webpack-plugin#options)
 - **Default**: `{ template: "./public/index.html" }`
 
 To remove the default instance of [html-webpack-plugin](https://webpack.js.org/plugins/html-webpack-plugin/), set the property to `false`.
@@ -403,7 +403,7 @@ We recommend instead to define environment variables using [cross-env](https://g
 import { defineBuildConfig } from "@workleap/webpack-configs";
 import { swcConfig } from "./swc.build.js";
 
-if (process.env.DEBUG === "true") {
+if (process.env.DEBUG) {
     console.log("Configuring webpack in debug mode!");
 }
 
@@ -416,7 +416,7 @@ To make them accessible to the application files, webpack must be aware of those
 
 ### `environmentVariables`
 
-- **Type**: `Record<string, string | undefined>`
+- **Type**: `Record<string, unknown>`
 - **Default**: `{}`
 
 First, define the variables with `environmentVariables`:
@@ -429,7 +429,7 @@ import { swcConfig } from "./swc.build.js";
 
 export default defineBuildConfig(swcConfig, {
     environmentVariables: {
-        "DEBUG": process.env.DEBUG
+        "DEBUG": process.env.DEBUG === "true"
     }
 });
 ```
@@ -438,13 +438,17 @@ Then, use the variables in any application files:
 
 ```tsx !#2 src/app.tsx
 export function App() {
-    if (process.env.DEBUG === "true") {
+    if (process.env.DEBUG) {
         console.log("The application has been bootstrapped in debug!");
     }
 
     return null;
 }
 ```
+
+!!!
+The `=== "true"` part of `"DEBUG": process.env.DEBUG === "true"` is very important, otherwise the environment variable value would be `"true"` instead of `true`.
+!!!
 
 ## 7. Try it :rocket:
 

--- a/docs/webpack/configure-dev.md
+++ b/docs/webpack/configure-dev.md
@@ -220,7 +220,7 @@ export default defineDevConfig(swcConfig, {
 
 ### `htmlWebpackPlugin`
 
-- **Type**: `false` or an object literal accepting any `html-webpack-plugin` [option](https://github.com/jantimon/html-webpack-plugin#options)
+- **Type**: `boolean` or an object literal accepting any `html-webpack-plugin` [option](https://github.com/jantimon/html-webpack-plugin#options)
 - **Default**: `{ template: "./public/index.html" }`
 
 To remove the default instance of [html-webpack-plugin](https://webpack.js.org/plugins/html-webpack-plugin/), set the property to `false`.
@@ -418,7 +418,7 @@ We recommend instead to define environment variables using [cross-env](https://g
 import { defineDevConfig } from "@workleap/webpack-configs";
 import { swcConfig } from "./swc.dev.js";
 
-if (process.env.DEBUG === "true") {
+if (process.env.DEBUG) {
     console.log("Configuring webpack in debug mode!");
 }
 
@@ -431,7 +431,7 @@ To make them accessible to the application files, webpack must be aware of those
 
 ### `environmentVariables`
 
-- **Type**: `Record<string, string | undefined>`
+- **Type**: `Record<string, unknown>`
 - **Default**: `{}`
 
 First, define the variables with `environmentVariables`:
@@ -444,7 +444,7 @@ import { swcConfig } from "./swc.dev.js";
 
 export default defineDevConfig(swcConfig, {
     environmentVariables: {
-        "DEBUG": process.env.DEBUG
+        "DEBUG": process.env.DEBUG === "true"
     }
 });
 ```
@@ -453,13 +453,17 @@ Then, use the variables in any application files:
 
 ```tsx !#2 src/app.tsx
 export function App() {
-    if (process.env.DEBUG === "true") {
+    if (process.env.DEBUG) {
         console.log("The application has been bootstrapped in debug!");
     }
 
     return null;
 }
 ```
+
+!!!
+The `=== "true"` part of `"DEBUG": process.env.DEBUG === "true"` is very important, otherwise the environment variable value would be `"true"` instead of `true`.
+!!!
 
 ## 7. Try it :rocket:
 

--- a/packages/webpack-configs/package.json
+++ b/packages/webpack-configs/package.json
@@ -59,6 +59,7 @@
         "@swc/helpers": "0.5.1",
         "@swc/jest": "0.2.29",
         "@types/jest": "29.5.4",
+        "@types/node": "20.5.7",
         "@workleap/eslint-plugin": "workspace:*",
         "@workleap/swc-configs": "workspace:*",
         "@workleap/tsup-configs": "workspace:*",

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -1,8 +1,10 @@
 import { defineBuildConfig as defineSwcConfig } from "@workleap/swc-configs";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 import type { Configuration, FileCacheOptions, RuleSetRule } from "webpack";
 import { defineBuildConfig, defineBuildHtmlWebpackPluginConfig, defineMiniCssExtractPluginConfig } from "../src/build.ts";
 import type { WebpackConfigTransformer } from "../src/transformers/applyTransformers.ts";
 import { findModuleRule, matchLoaderName } from "../src/transformers/moduleRules.ts";
+import { findPlugin, matchConstructorName } from "../src/transformers/plugins.ts";
 
 const Targets = {
     chrome: "116"
@@ -140,6 +142,26 @@ test("when a cache directory is provided and cache is enabled, use the provided 
     });
 
     expect((result.cache as FileCacheOptions).cacheDirectory).toBe("a-custom-path");
+});
+
+test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is added to the plugin array", () => {
+    const config = defineBuildConfig(defineSwcConfig(Targets), {
+        htmlWebpackPlugin: false
+    });
+
+    const result = findPlugin(config, matchConstructorName(HtmlWebpackPlugin.name));
+
+    expect(result).toBeUndefined();
+});
+
+test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is added to the plugin array", () => {
+    const config = defineBuildConfig(defineSwcConfig(Targets), {
+        htmlWebpackPlugin: true
+    });
+
+    const result = findPlugin(config, matchConstructorName(HtmlWebpackPlugin.name));
+
+    expect(result).toBeDefined();
 });
 
 test("when css modules is enabled, include css modules configuration", () => {

--- a/packages/webpack-configs/tests/dev.test.ts
+++ b/packages/webpack-configs/tests/dev.test.ts
@@ -1,10 +1,12 @@
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
 import type { Config as SwcConfig } from "@swc/core";
 import { defineDevConfig as defineSwcConfig } from "@workleap/swc-configs";
+import HtmlWebpackPlugin from "html-webpack-plugin";
 import type { Configuration, FileCacheOptions, RuleSetRule } from "webpack";
 import { defineDevConfig, defineDevHtmlWebpackPluginConfig, defineFastRefreshPluginConfig } from "../src/dev.ts";
 import type { WebpackConfigTransformer } from "../src/transformers/applyTransformers.ts";
 import { findModuleRule, matchLoaderName } from "../src/transformers/moduleRules.ts";
+import { findPlugin, matchConstructorName } from "../src/transformers/plugins.ts";
 
 const Targets = {
     chrome: "116"
@@ -158,6 +160,26 @@ test("when additional plugins are provided, append the provided plugins at the e
 
     expect(result.plugins![pluginsCount - 2]).toBe(newPlugin1);
     expect(result.plugins![pluginsCount - 1]).toBe(newPlugin2);
+});
+
+test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is added to the plugin array", () => {
+    const config = defineDevConfig(defineSwcConfig(Targets), {
+        htmlWebpackPlugin: false
+    });
+
+    const result = findPlugin(config, matchConstructorName(HtmlWebpackPlugin.name));
+
+    expect(result).toBeUndefined();
+});
+
+test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is added to the plugin array", () => {
+    const config = defineDevConfig(defineSwcConfig(Targets), {
+        htmlWebpackPlugin: true
+    });
+
+    const result = findPlugin(config, matchConstructorName(HtmlWebpackPlugin.name));
+
+    expect(result).toBeDefined();
 });
 
 test("when fast refresh is disabled, dev server hot module reload is enabled", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       '@types/jest':
         specifier: 29.5.4
         version: 29.5.4
+      '@types/node':
+        specifier: 20.5.7
+        version: 20.5.7
       '@workleap/eslint-plugin':
         specifier: workspace:*
         version: link:../eslint-plugin

--- a/sample/app/src/index.tsx
+++ b/sample/app/src/index.tsx
@@ -4,7 +4,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 
-if (process.env.USE_MSW) {
+if (process.env.USE_MSW === "true") {
     import("../mocks/browser.ts").then(({ worker }) => {
         worker.start();
     });

--- a/sample/app/webpack.build.js
+++ b/sample/app/webpack.build.js
@@ -6,6 +6,6 @@ import { swcConfig } from "./swc.build.js";
 export default defineBuildConfig(swcConfig, {
     profile: process.env.PROFILE === "true",
     environmentVariables: {
-        "USE_MSW": "false"
+        "USE_MSW": process.env.USE_MSW === "true"
     }
 });

--- a/sample/app/webpack.dev.js
+++ b/sample/app/webpack.dev.js
@@ -6,6 +6,8 @@ import { swcConfig } from "./swc.dev.js";
 export default defineDevConfig(swcConfig, {
     profile: process.env.PROFILE === "true",
     environmentVariables: {
-        "USE_MSW": process.env.USE_MSW
+        "USE_MSW": process.env.USE_MSW === "true",
+        "STRING": "STRING_VALUE",
+        "INT": 1
     }
 });


### PR DESCRIPTION
## Changes

### `@workleap/webpack-configs`

- `htmlWebpackPlugin` option now accept a `boolean` value rather than only `false`
- Fixing `environmentVariables` by stringifying all the values (view https://webpack.js.org/plugins/define-plugin/ for more info)

## Release

- Minor bump for `@workleap/webpack-configs`