### PR TITLE
fix: added a default key to webpack-configs exports field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,8 @@ ESM only package:
     "exports": {
         ".": {
             "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
         }
     }
 }

--- a/docs/webpack/transformer-utilities.md
+++ b/docs/webpack/transformer-utilities.md
@@ -377,7 +377,7 @@ A plugin if a match has been found, otherwise `undefined`.
 
 #### Usage
 
-```ts transformer.ts
+```ts !#5 transformer.ts
 import { matchConstructorName, findPlugin, type WebpackConfig } from "@workleap/webpack-configs";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 

--- a/packages/stylelint-configs/package.json
+++ b/packages/stylelint-configs/package.json
@@ -18,7 +18,6 @@
             "types": "./dist/index.d.ts"
         }
     },
-    "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "files": [
         "dist",

--- a/packages/webpack-configs/package.json
+++ b/packages/webpack-configs/package.json
@@ -13,7 +13,8 @@
     "exports": {
         ".": {
             "import": "./dist/index.js",
-            "types": "./dist/index.d.ts"
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
         }
     },
     "files": [

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -44,6 +44,14 @@ export function defineMiniCssExtractPluginConfig(options: MiniCssExtractPluginOp
     };
 }
 
+function preflight(options: DefineBuildConfigOptions) {
+    if (options.publicPath) {
+        if (!options.publicPath.endsWith("/")) {
+            throw new Error("[webpack-configs] The \"publicPath\" must end with a \"/\".");
+        }
+    }
+}
+
 export interface DefineBuildConfigOptions {
     entry?: string;
     outputPath?: string;
@@ -62,6 +70,8 @@ export interface DefineBuildConfigOptions {
 }
 
 export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConfigOptions = {}) {
+    preflight(options);
+
     const {
         entry = path.resolve("./src/index.tsx"),
         outputPath = path.resolve("dist"),

--- a/packages/webpack-configs/src/dev.ts
+++ b/packages/webpack-configs/src/dev.ts
@@ -54,15 +54,9 @@ export interface DefineDevConfigOptions {
     profile?: boolean;
 }
 
-function preflight(options: DefineDevConfigOptions) {
+function preflight() {
     if (!require.resolve("webpack-dev-server")) {
         throw new Error("[webpack-configs] To use the \"dev\" config, install https://www.npmjs.com/package/webpack-dev-server as a \"devDependency\".");
-    }
-
-    if (options.fastRefresh) {
-        if (!require.resolve("@pmmmwh/react-refresh-webpack-plugin")) {
-            throw new Error("[webpack-configs] To use Webpack Fast Refresh, install https://www.npmjs.com/package/@pmmmwh/react-refresh-webpack-plugin as a \"devDependency\".");
-        }
     }
 }
 
@@ -75,7 +69,7 @@ function trySetSwcFastRefresh(config: SwcConfig, enabled: boolean) {
 }
 
 export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOptions = {}) {
-    preflight(options);
+    preflight();
 
     const {
         entry = path.resolve("./src/index.tsx"),

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -6,12 +6,12 @@ import type { WebpackConfigTransformer } from "../src/transformers/applyTransfor
 import { findModuleRule, matchLoaderName } from "../src/transformers/moduleRules.ts";
 import { findPlugin, matchConstructorName } from "../src/transformers/plugins.ts";
 
-const Targets = {
+const SwcConfig = defineSwcConfig({
     chrome: "116"
-};
+});
 
 test("when an entry prop is provided, use the provided entry value", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         entry: "./a-new-entry.ts"
     });
 
@@ -19,7 +19,7 @@ test("when an entry prop is provided, use the provided entry value", () => {
 });
 
 test("when an output path is provided, use the provided ouput path value", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         outputPath: "./a-new-output-path"
     });
 
@@ -27,7 +27,7 @@ test("when an output path is provided, use the provided ouput path value", () =>
 });
 
 test("when a public path is provided, use the provided public path value", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         publicPath: "./a-new-public-path"
     });
 
@@ -45,7 +45,7 @@ test("when additional module rules are provided, append the provided rules at th
         type: "asset/inline"
     };
 
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         moduleRules: [
             newModuleRule1,
             newModuleRule2
@@ -74,7 +74,7 @@ test("when additional plugins are provided, append the provided plugins at the e
     const newPlugin1 = new Plugin1();
     const newPlugin2 = new Plugin2();
 
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         plugins: [
             newPlugin1,
             newPlugin2
@@ -88,7 +88,7 @@ test("when additional plugins are provided, append the provided plugins at the e
 });
 
 test("when minify is true, minimize is set to true", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         minify: true
     });
 
@@ -96,7 +96,7 @@ test("when minify is true, minimize is set to true", () => {
 });
 
 test("when minify is false, minimize is set to false", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         minify: false
     });
 
@@ -104,7 +104,7 @@ test("when minify is false, minimize is set to false", () => {
 });
 
 test("when minify is true, include minify configuration", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         minify: true
     });
 
@@ -112,7 +112,7 @@ test("when minify is true, include minify configuration", () => {
 });
 
 test("when minify is false, do not include minify configuration", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         minify: false
     });
 
@@ -120,7 +120,7 @@ test("when minify is false, do not include minify configuration", () => {
 });
 
 test("when cache is enabled, the cache configuration is included", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         cache: true
     });
 
@@ -128,7 +128,7 @@ test("when cache is enabled, the cache configuration is included", () => {
 });
 
 test("when cache is disabled, the cache prop is false", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         cache: false
     });
 
@@ -136,7 +136,7 @@ test("when cache is disabled, the cache prop is false", () => {
 });
 
 test("when a cache directory is provided and cache is enabled, use the provided cache directory value", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         cache: true,
         cacheDirectory: "a-custom-path"
     });
@@ -145,7 +145,7 @@ test("when a cache directory is provided and cache is enabled, use the provided 
 });
 
 test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is added to the plugin array", () => {
-    const config = defineBuildConfig(defineSwcConfig(Targets), {
+    const config = defineBuildConfig(SwcConfig, {
         htmlWebpackPlugin: false
     });
 
@@ -155,7 +155,7 @@ test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is ad
 });
 
 test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is added to the plugin array", () => {
-    const config = defineBuildConfig(defineSwcConfig(Targets), {
+    const config = defineBuildConfig(SwcConfig, {
         htmlWebpackPlugin: true
     });
 
@@ -165,7 +165,7 @@ test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is add
 });
 
 test("when css modules is enabled, include css modules configuration", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         cssModules: true
     });
 
@@ -180,7 +180,7 @@ test("when css modules is enabled, include css modules configuration", () => {
 });
 
 test("when css modules is disabled, do not include css modules configuration", () => {
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         cssModules: false
     });
 
@@ -190,7 +190,7 @@ test("when css modules is disabled, do not include css modules configuration", (
 });
 
 test("the provided swc config object is set as the swc-loader options", () => {
-    const swcConfig = defineSwcConfig(Targets);
+    const swcConfig = SwcConfig;
 
     const result = defineBuildConfig(swcConfig);
 
@@ -206,7 +206,7 @@ test("when a transformer is provided, the transformer is applied on the webpack 
         return config;
     };
 
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         transformers: [entryTransformer]
     });
 
@@ -226,7 +226,7 @@ test("when multiple transformers are provided, all the transformers are applied 
         return config;
     };
 
-    const result = defineBuildConfig(defineSwcConfig(Targets), {
+    const result = defineBuildConfig(SwcConfig, {
         transformers: [entryTransformer, devToolTransformer]
     });
 
@@ -237,7 +237,7 @@ test("when multiple transformers are provided, all the transformers are applied 
 test("transformers context environment is \"build\"", () => {
     const mockTransformer = jest.fn();
 
-    defineBuildConfig(defineSwcConfig(Targets), {
+    defineBuildConfig(SwcConfig, {
         transformers: [mockTransformer]
     });
 
@@ -247,7 +247,7 @@ test("transformers context environment is \"build\"", () => {
 test("when the profile option is true, the transformers context profile value is \"true\"", () => {
     const mockTransformer = jest.fn();
 
-    defineBuildConfig(defineSwcConfig(Targets), {
+    defineBuildConfig(SwcConfig, {
         profile: true,
         transformers: [mockTransformer]
     });

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -247,7 +247,7 @@ test("transformers context environment is \"build\"", () => {
 test("when the verbose option is true, the transformers context verbose value is \"true\"", () => {
     const mockTransformer = jest.fn();
 
-    defineBuildConfig(defineSwcConfig(Targets), {
+    defineBuildConfig(SwcConfig, {
         verbose: true,
         transformers: [mockTransformer]
     });

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -26,12 +26,16 @@ test("when an output path is provided, use the provided ouput path value", () =>
     expect(result.output?.path).toBe("./a-new-output-path");
 });
 
-test("when a public path is provided, use the provided public path value", () => {
+test("when a public path not ending with a trailing slash is provided, throw an error", () => {
+    expect(() => defineBuildConfig(SwcConfig, { publicPath: "an-invalid-public-path" })).toThrow();
+});
+
+test("when a valid public path is provided, use the provided public path value", () => {
     const result = defineBuildConfig(SwcConfig, {
-        publicPath: "./a-new-public-path"
+        publicPath: "a-valid-public-path-ending-with-a-trailing-slash/"
     });
 
-    expect(result.output?.publicPath).toBe("./a-new-public-path");
+    expect(result.output?.publicPath).toBe("a-valid-public-path-ending-with-a-trailing-slash/");
 });
 
 test("when additional module rules are provided, append the provided rules at the end of the module rules array", () => {

--- a/packages/webpack-configs/tests/dev.test.ts
+++ b/packages/webpack-configs/tests/dev.test.ts
@@ -1,5 +1,5 @@
 import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin";
-import type { Config as SwcConfig } from "@swc/core";
+import { Config as SwcConfig } from "@swc/core";
 import { defineDevConfig as defineSwcConfig } from "@workleap/swc-configs";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import type { Configuration, FileCacheOptions, RuleSetRule } from "webpack";
@@ -8,12 +8,12 @@ import type { WebpackConfigTransformer } from "../src/transformers/applyTransfor
 import { findModuleRule, matchLoaderName } from "../src/transformers/moduleRules.ts";
 import { findPlugin, matchConstructorName } from "../src/transformers/plugins.ts";
 
-const Targets = {
+const SwcConfig = defineSwcConfig({
     chrome: "116"
-};
+});
 
 test("when an entry prop is provided, use the provided entry value", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         entry: "./a-new-entry.ts"
     });
 
@@ -21,7 +21,7 @@ test("when an entry prop is provided, use the provided entry value", () => {
 });
 
 test("when https is enabled, the dev server is configured for https", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         https: true
     });
 
@@ -29,7 +29,7 @@ test("when https is enabled, the dev server is configured for https", () => {
 });
 
 test("when https is disabled, the dev server is not configured for https", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         https: false
     });
 
@@ -37,7 +37,7 @@ test("when https is disabled, the dev server is not configured for https", () =>
 });
 
 test("when https is enabled, the public path starts with https", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         https: true
     });
 
@@ -45,7 +45,7 @@ test("when https is enabled, the public path starts with https", () => {
 });
 
 test("when https is disabled, the public path starts with http", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         https: false
     });
 
@@ -53,7 +53,7 @@ test("when https is disabled, the public path starts with http", () => {
 });
 
 test("when an host is provided, the dev server host is the provided host value", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         host: "a-custom-host"
     });
 
@@ -61,7 +61,7 @@ test("when an host is provided, the dev server host is the provided host value",
 });
 
 test("when an host is provided, the public path include the provided host value", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         host: "a-custom-host"
     });
 
@@ -69,7 +69,7 @@ test("when an host is provided, the public path include the provided host value"
 });
 
 test("when a port is provided, the dev server port is the provided port value", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         port: 1234
     });
 
@@ -77,7 +77,7 @@ test("when a port is provided, the dev server port is the provided port value", 
 });
 
 test("when a port is provided, the public path include the provided port", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         port: 1234
     });
 
@@ -85,7 +85,7 @@ test("when a port is provided, the public path include the provided port", () =>
 });
 
 test("when cache is enabled, the cache configuration is included", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         cache: true
     });
 
@@ -93,7 +93,7 @@ test("when cache is enabled, the cache configuration is included", () => {
 });
 
 test("when cache is disabled, the cache prop is false", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         cache: false
     });
 
@@ -101,7 +101,7 @@ test("when cache is disabled, the cache prop is false", () => {
 });
 
 test("when a cache directory is provided and cache is enabled, use the provided cache directory value", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         cache: true,
         cacheDirectory: "a-custom-path"
     });
@@ -120,7 +120,7 @@ test("when additional module rules are provided, append the provided rules at th
         type: "asset/inline"
     };
 
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         moduleRules: [
             newModuleRule1,
             newModuleRule2
@@ -149,7 +149,7 @@ test("when additional plugins are provided, append the provided plugins at the e
     const newPlugin1 = new Plugin1();
     const newPlugin2 = new Plugin2();
 
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         plugins: [
             newPlugin1,
             newPlugin2
@@ -163,7 +163,7 @@ test("when additional plugins are provided, append the provided plugins at the e
 });
 
 test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is added to the plugin array", () => {
-    const config = defineDevConfig(defineSwcConfig(Targets), {
+    const config = defineDevConfig(SwcConfig, {
         htmlWebpackPlugin: false
     });
 
@@ -173,7 +173,7 @@ test("when htmlWebpackPlugin is \"false\", no html-webpack-plugin instance is ad
 });
 
 test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is added to the plugin array", () => {
-    const config = defineDevConfig(defineSwcConfig(Targets), {
+    const config = defineDevConfig(SwcConfig, {
         htmlWebpackPlugin: true
     });
 
@@ -183,7 +183,7 @@ test("when htmlWebpackPlugin is \"true\", an html-webpack-plugin instance is add
 });
 
 test("when fast refresh is disabled, dev server hot module reload is enabled", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         fastRefresh: false
     });
 
@@ -191,7 +191,7 @@ test("when fast refresh is disabled, dev server hot module reload is enabled", (
 });
 
 test("when fast refresh is enabled, add the fast refresh plugin", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         fastRefresh: true
     });
 
@@ -199,7 +199,7 @@ test("when fast refresh is enabled, add the fast refresh plugin", () => {
 });
 
 test("when fast refresh is disabled, do not add the fast refresh plugin", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         fastRefresh: false
     });
 
@@ -207,7 +207,7 @@ test("when fast refresh is disabled, do not add the fast refresh plugin", () => 
 });
 
 test("when fast refresh is enabled, enable swc fast refresh", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         fastRefresh: true
     });
 
@@ -217,7 +217,7 @@ test("when fast refresh is enabled, enable swc fast refresh", () => {
 });
 
 test("when fast refresh is disabled, disable swc fast refresh", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         fastRefresh: false
     });
 
@@ -227,7 +227,7 @@ test("when fast refresh is disabled, disable swc fast refresh", () => {
 });
 
 test("when css modules is enabled, include css modules configuration", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         cssModules: true
     });
 
@@ -242,7 +242,7 @@ test("when css modules is enabled, include css modules configuration", () => {
 });
 
 test("when css modules is disabled, do not include css modules configuration", () => {
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         cssModules: false
     });
 
@@ -252,7 +252,7 @@ test("when css modules is disabled, do not include css modules configuration", (
 });
 
 test("the provided swc config object is set as the swc-loader options", () => {
-    const swcConfig = defineSwcConfig(Targets);
+    const swcConfig = SwcConfig;
 
     const result = defineDevConfig(swcConfig);
 
@@ -268,7 +268,7 @@ test("when a transformer is provided, the transformer is applied on the webpack 
         return config;
     };
 
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         transformers: [entryTransformer]
     });
 
@@ -288,7 +288,7 @@ test("when multiple transformers are provided, all the transformers are applied 
         return config;
     };
 
-    const result = defineDevConfig(defineSwcConfig(Targets), {
+    const result = defineDevConfig(SwcConfig, {
         transformers: [entryTransformer, devToolTransformer]
     });
 
@@ -299,7 +299,7 @@ test("when multiple transformers are provided, all the transformers are applied 
 test("transformers context environment is \"dev\"", () => {
     const mockTransformer = jest.fn();
 
-    defineDevConfig(defineSwcConfig(Targets), {
+    defineDevConfig(SwcConfig, {
         transformers: [mockTransformer]
     });
 
@@ -309,7 +309,7 @@ test("transformers context environment is \"dev\"", () => {
 test("when the profile option is true, the transformers context profile value is \"true\"", () => {
     const mockTransformer = jest.fn();
 
-    defineDevConfig(defineSwcConfig(Targets), {
+    defineDevConfig(SwcConfig, {
         profile: true,
         transformers: [mockTransformer]
     });

--- a/sample/app/package.json
+++ b/sample/app/package.json
@@ -12,11 +12,11 @@
     "scripts": {
         "dev": "webpack serve --config webpack.dev.js",
         "dev-msw": "cross-env USE_MSW=true webpack serve --config webpack.dev.js",
-        "verbose-dev": "cross-env VERBOSE=true webpack serve --config webpack.dev.js",
-        "verbose-dev-msw": "cross-env USE_MSW=true VERBOSE=true webpack serve --config webpack.dev.js",
+        "dev-verbose": "cross-env VERBOSE=true webpack serve --config webpack.dev.js",
+        "dev-msw-verbose": "cross-env USE_MSW=true VERBOSE=true webpack serve --config webpack.dev.js",
         "build": "webpack --config webpack.build.js",
         "serve-build": "pnpm build && pnpm http-server dist -p 8080 -P http://localhost:8080? -c-1",
-        "verbose-build": "cross-env PROFILE=true webpack --config webpack.build.js"
+        "build-verbose": "cross-env PROFILE=true webpack --config webpack.build.js"
     },
     "devDependencies": {
         "@svgr/webpack": "8.1.0",

--- a/sample/app/src/index.tsx
+++ b/sample/app/src/index.tsx
@@ -4,7 +4,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
 
-if (process.env.USE_MSW === "true") {
+if (process.env.USE_MSW) {
     import("../mocks/browser.ts").then(({ worker }) => {
         worker.start();
     });


### PR DESCRIPTION
## Changes

### `@workleap/webpack-configs`

- Added a `default` key to `exports` for Jest support on the consumer side
- Added a check to ensure that `defineBuildConfig` receive a `publicPath` ending with a trailing `/`

### Sample

- Fix MSW activation

## Release

- Patch bump for `@workleap/webpack-configs`