### PR TITLE
chore: update swc core to 1.3.85

### DIFF
--- a/.changeset/three-meals-shop.md
+++ b/.changeset/three-meals-shop.md
@@ -1,0 +1,9 @@
+---
+"@workleap/postcss-configs": patch
+"@workleap/webpack-configs": patch
+"@workleap/eslint-plugin": patch
+"@workleap/tsup-configs": patch
+"@workleap/swc-configs": patch
+---
+
+Updated to SWC 1.3.85

--- a/docs/browserslist/configure-project.md
+++ b/docs/browserslist/configure-project.md
@@ -8,7 +8,7 @@ meta:
 
 > Only setup [Browserslist](https://browsersl.ist/) for projects that are **emitting application bundles**. For example, a library project shouldn't include Browserslist but a web application project should.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -26,7 +26,7 @@ npm install -D @workleap/browserslist-config browserslist
 ```
 +++
 
-## 2. Configure Browserslist
+## Configure Browserslist
 
 First, create a configuration file named `.browserslistrc` at the root of the project:
 
@@ -44,7 +44,7 @@ Then, open the newly created file and extend the default configuration with the 
 extends @workleap/browserslist-config
 ```
 
-### Custom browsers
+## Support custom browsers
 
 If you are encountering a situation that is not currently handled by `@workleap/browserslist-configs`, you can customize your configuration file to extend this library shared configurations with additional browser versions:
 
@@ -56,7 +56,7 @@ last 2 OperaMobile 12.1 versions
 
 Refer to the [Browserslist documentation](https://github.com/browserslist/browserslist#full-list) for a full list of available queries.
 
-## 4. Try it :rocket:
+## Try it :rocket:
 
 To test your new Browserslist configuration, open a terminal at the root of the project and execute the following command:
 

--- a/docs/eslint/custom-configuration.md
+++ b/docs/eslint/custom-configuration.md
@@ -63,7 +63,7 @@ Please, don't update your project configuration to use single quotes :sweat_smil
 
 ## Add a plugin
 
-You can add new rules from a third party [ESLint plugin](https://eslint.org/docs/latest/use/configure/plugins):
+You can add configure additional rules from a third party [ESLint plugin](https://eslint.org/docs/latest/use/configure/plugins):
 
 ```json !#4,6-8 .eslintrc.json
 {

--- a/docs/eslint/integrate-vscode.md
+++ b/docs/eslint/integrate-vscode.md
@@ -9,11 +9,11 @@ meta:
 
 [ESLint VS Code extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) greatly improve the development experience by **automatically linting** the code as you type and **automatically formatting** the code according to your ESLint configuration whenever you save.
 
-## 1. Install the ESLint extension
+## Install ESLint extension
 
 Open VS Code and install the [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) extension.
 
-## 2. Configure VS Code
+## Configure VS Code
 
 Then, add the following settings to your solution [VS Code settings file](https://code.visualstudio.com/docs/getstarted/settings):
 
@@ -30,11 +30,11 @@ Then, add the following settings to your solution [VS Code settings file](https:
 }
 ```
 
-## 3. Install the EditorConfig extension
+## Install EditorConfig extension
 
 Finally, install the [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) extension.
 
-## 4. Try it :rocket:
+## Try it :rocket:
 
 Restart VS Code, open a JavaScript file, type invalid code (e.g. `var x = 0;`), then save. The code should have been formatted automatically (e.g. `const x = 0;`).
 

--- a/docs/eslint/setup-monorepo-2.md
+++ b/docs/eslint/setup-monorepo-2.md
@@ -1,0 +1,252 @@
+---
+order: 90
+label: Setup a monorepo 2
+meta:
+    title: Configure a monorepo - ESLint
+toc:
+    depth: 2-4
+---
+
+# Setup a monorepo
+
+!!!warning
+This monorepo setup is intended to be used with [PNPM workspaces](https://pnpm.io/workspaces). You may need a different setup for [NPM workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) or [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) because by default, those package managers **hoist dependencies** rather than installing them in isolation like PNPM.
+!!!
+
+To lint a monorepo solution (**multiple projects** per repository), [ESLint](https://eslint.org/) must be setuped to lint the files at the root of the solution (the monorepo **workspace**) and the files of every project of the monorepo. Execute the following steps to setup ESLint for a monorepo solution.
+
+## Setup the workspace
+
+### Install the packages
+
+Open a terminal at the root of the solution workspace (the **root** of the repository) and install the following packages:
+
++++ pnpm
+```bash
+pnpm add -D @workleap/eslint-plugin eslint typescript @typescript-eslint/parser
+```
++++ yarn
+```bash
+yarn add -D @workleap/eslint-plugin eslint typescript @typescript-eslint/parser
+```
++++ npm
+```bash
+npm install -D @workleap/eslint-plugin eslint typescript @typescript-eslint/parser
+```
++++
+
+### Configure ESLint
+
+First, create a configuration file named `.eslintrc.json` at the root of the solution workspace:
+
+``` !#8
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json
+├── .eslintrc.json
+```
+
+Then, open the newly created file and extend the default configuration with the `monorepo-workspace` shared configurations:
+
+```json !#4 .eslintrc.json
+{
+    "$schema": "https://json.schemastore.org/eslintrc",
+    "root": true,
+    "extends": "plugin:@workleap/monorepo-workspace"
+}
+```
+
+#### .eslintignore
+
+ESLint can be configured to [ignore](https://eslint.org/docs/latest/use/configure/ignore) certain files and directories while linting by specifying one or more glob patterns.
+
+To do so, first, create a `.eslintignore` file at the root of the solution workspace:
+
+``` !#9
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json
+├── .eslintrc.json
+├── .eslintignore
+```
+
+Then, open the newly created file and paste the following ignore rules:
+
+```bash .eslintignore
+**/dist/*
+node_modules
+*.md
+*.yml
+*.yaml
+```
+
+### Configure indent style
+
+ESLint offers [built-in rules](https://eslint.org/docs/latest/rules/indent) for configuring the indentation style of a codebase. However, there's a catch: when [VS Code auto-formatting](https://code.visualstudio.com/docs/editor/codebasics#_formatting) feature is enabled, it might conflict with the configured indentation rules if they are set differently.
+
+To guarantee a consistent indentation, we recommend using [EditorConfig](https://editorconfig.org/) on the consumer side. With EditorConfig, the indent style can be configured in a single file and be applied consistently across various formatting tools, including ESlint and [VS Code](https://code.visualstudio.com/).
+
+First, create a `.editorconfig` file at the root of the solution workspace:
+
+``` !#10
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json
+├── .eslintrc.json
+├── .eslintignore
+├── .editorconfig
+```
+
+Then, open the newly created file and paste the following configuration:
+
+```bash .editorconfig
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+```
+
+### Add a CLI script
+
+At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's workspace `package.json` file:
+
+``` !#7
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json    <------- (this one!)
+├── .eslintrc.json
+├── .eslintignore
+├── .editorconfig
+```
+
+```json package.json
+{
+    "lint:eslint:": "eslint . --max-warnings=1 --cache --cache-location node_modules/.cache/eslint"
+}
+```
+
+> The script definition may vary depending of your needs and your application configuration. For example, you might want to specify specific file extensions such as `--ext .js,.ts,.tsx`.
+
+## Setup a project
+
+### Install the package
+
+Open a terminal at the root of the project (`packages/app` for this example) and install the following package:
+
++++ pnpm
+```bash
+pnpm add -D @workleap/eslint-plugin
+```
++++ yarn
+```bash
+yarn add -D @workleap/eslint-plugin
+```
++++ npm
+```bash
+npm install -D @workleap/eslint-plugin
+```
++++
+
+### Configure ESLint
+
+First, create a configuration file named `.eslintrc.json` at the root of the project:
+
+``` !#7
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├────── .eslintrc.json
+├── package.json
+├── .eslintrc.json
+├── .eslintignore
+├── .editorconfig
+```
+
+Then, open the newly created file and extend the default configuration with one of the [shared configurations](/eslint/#available-configurations) provided by `@workleap/eslint-plugin` :point_down:
+
+#### `web-application`
+
+For an application developed with TypeScript and React, use the following configuration:
+
+```json !#4 packages/app/.eslintrc.json
+{
+    "$schema": "https://json.schemastore.org/eslintrc",
+    "root": true,
+    "extends": "plugin:@workleap/web-application"
+}
+```
+
+#### `react-library`
+
+For a TypeScript library developed **with** React, use the following configuration:
+
+```json !#4 packages/app/.eslintrc.json
+{
+    "$schema": "https://json.schemastore.org/eslintrc",
+    "root": true,
+    "extends": "plugin:@workleap/react-library"
+}
+```
+
+#### `typescript-library`
+
+For a TypeScript library developed **without** React, use the following configuration:
+
+```json !#4 packages/app/.eslintrc.json
+{
+    "$schema": "https://json.schemastore.org/eslintrc",
+    "root": true,
+    "extends": "plugin:@workleap/typescript-library"
+}
+```
+
+## Custom configuration
+
+New projects shouldn't have to customize the default configurations offered by `@workleap/eslint-plugin`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
+
+## Try it :rocket:
+
+To test your new ESLint setup, open a JavaScript file, type invalid code (e.g. `var x = 0;`), then save. Open a terminal at the root of the solution and execute the [CLI script added earlier](#add-a-cli-script):
+
++++ pnpm
+```bash
+pnpm lint:eslint
+```
++++ yarn
+```bash
+yarn lint:eslint
+```
++++ npm
+```bash
+npm run lint:eslint
+```
++++
+
+The terminal should output a linting error.

--- a/docs/eslint/setup-polyrepo.md
+++ b/docs/eslint/setup-polyrepo.md
@@ -9,7 +9,7 @@ meta:
 
 Execute the following steps to setup [ESLint](https://eslint.org/) for a polyrepo solution (**single project** per repository).
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the solution and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/eslint-plugin eslint @typescript-eslint/parser
 ```
 +++
 
-## 2. Configure ESLint
+## Configure ESLint
 
 First, create a configuration file named `.eslintrc.json` at the root of the solution:
 
@@ -41,7 +41,7 @@ root
 
 Then, open the newly created file and extend the default configuration with one of the [shared configurations](default.md#available-configurations) provided by `@workleap/eslint-plugin` :point_down:
 
-### web-application
+### `web-application`
 
 For an application developed with TypeScript and React, use the following configuration:
 
@@ -53,7 +53,7 @@ For an application developed with TypeScript and React, use the following config
 }
 ```
 
-### react-library
+### `react-library`
 
 For a TypeScript library developed **with** React, use the following configuration:
 
@@ -65,7 +65,7 @@ For a TypeScript library developed **with** React, use the following configurati
 }
 ```
 
-### typescript-library
+### `typescript-library`
 
 For a TypeScript library developed **without** React, use the following configuration:
 
@@ -77,7 +77,7 @@ For a TypeScript library developed **without** React, use the following configur
 }
 ```
 
-## 3. Ignore files
+### .eslintignore
 
 ESLint can be configured to [ignore](https://eslint.org/docs/latest/use/configure/ignore) certain files and directories while linting by specifying one or more glob patterns.
 
@@ -102,7 +102,7 @@ node_modules
 *.yaml
 ```
 
-## 4. Configure indent style
+## Configure the indent style
 
 [ESLint](https://eslint.org/) offers [built-in rules](https://eslint.org/docs/latest/rules/indent) for configuring the indentation style of a codebase. However, there's a catch: when [VS Code auto-formatting](https://code.visualstudio.com/docs/editor/codebasics#_formatting) feature is enabled, it might conflict with the configured indentation rules if they are set differently.
 
@@ -139,7 +139,7 @@ trim_trailing_whitespace = false
 
 Finally, install the [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) VS Code extension.
 
-## 5. Add a CLI script
+## Add a CLI script
 
 At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's `package.json` file:
 
@@ -151,13 +151,13 @@ At times, especially when running the CI build, it's useful to lint the entire s
 
 > The script definition may vary depending of your needs and your application configuration. For example, you might want to specify specific file extensions such as `--ext .js,.ts,.tsx`.
 
-## 6. Customize configuration
+## Custom configuration
 
 New projects shouldn't have to customize the default configurations offered by `@workleap/eslint-plugin`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
 
-## 7. Try it :rocket:
+## Try it :rocket:
 
-To test your new ESLint setup, open a JavaScript file, type invalid code (e.g. `var x = 0;`), then save. Open a terminal at the root of the solution and execute the [CLI script added earlier](#5-add-a-cli-script):
+To test your new ESLint setup, open a JavaScript file, type invalid code (e.g. `var x = 0;`), then save. Open a terminal at the root of the solution and execute the [CLI script added earlier](#add-a-cli-script):
 
 +++ pnpm
 ```bash

--- a/docs/postcss/configure-project.md
+++ b/docs/postcss/configure-project.md
@@ -8,7 +8,7 @@ meta:
 
 Execute the following steps to setup [PostCSS](https://postcss.org/) for a single project.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -26,7 +26,7 @@ npm install -D @workleap/postcss-configs postcss
 ```
 +++
 
-## 2. Configure PostCSS
+## Configure PostCSS
 
 First, create a configuration file named `postcss.config.ts` at the root of the project:
 
@@ -46,7 +46,7 @@ import { defineConfig } from "@workleap/postcss-configs";
 export default defineConfig();
 ```
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineConfig(options)` function can be used as-is as shown in the previous example, however, if you wish to customize the default configuration, the function also accepts a few predefined options to help with that :point_down:
 
@@ -101,13 +101,13 @@ export default defineConfig({
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/postcss-configs/src/index.ts) of `@workleap/postcss-configs`, but only covers a subset of a [PostCSS configuration](https://github.com/postcss/postcss-load-config). If you need full control over the configuration, you can provide **configuration transformer** functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/postcss-configs/src/index.ts) of `@workleap/postcss-configs`, but only covers a subset of a [PostCSS configuration](https://github.com/postcss/postcss-load-config). If you need full control over the configuration, you can provide **configuration transformer** functions through the `transformers` option of the `defineConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default configuration of `@workleap/postcss-configs`, have a look at the [configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/postcss-configs/src/index) on GitHub.
 
@@ -153,7 +153,7 @@ export default defineConfig({
 });
 ```
 
-## 5. Configure webpack
+## Configure webpack
 
 To integrate with webpack, update your configuration file to include a [postcss-loader](https://www.npmjs.com/package/postcss-loader):
 
@@ -177,7 +177,7 @@ export default {
 }
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
 To test your new PostCSS configuration, create and import a CSS file with the following code:
 

--- a/docs/postcss/default.md
+++ b/docs/postcss/default.md
@@ -37,7 +37,7 @@ Here's a couple of ideas to move away from PostCSS:
 - Force developers to use `rem` by disabling the use of `px` with [Stylelint](https://stylelint.io/).
 - Prefix CSS properties directly in the codebase rather than relying on [Autoprefixer](https://github.com/postcss/autoprefixer). As browser vendors are now [putting experimental features behind a flag](https://github.com/postcss/autoprefixer) rather than using prefixes, there aren't many CSS properties still requiring a prefix.
 
-## Features
+## Main features
 
 The shared configuration offered by `@workleap/postcss-configs` includes the following features:
 

--- a/docs/stylelint/custom-configuration.md
+++ b/docs/stylelint/custom-configuration.md
@@ -59,7 +59,7 @@ You can update a default rule value by defining the rule locally with its new va
 
 ## Add a plugin
 
-You can add new rules from a third party [Stylelint plugin](https://stylelint.io/user-guide/configure#plugins):
+You can configure additional rules from a third party [Stylelint plugin](https://stylelint.io/user-guide/configure#plugins):
 
 ```json !#3,5-10 .stylelintrc.json
 {

--- a/docs/stylelint/integrate-vscode.md
+++ b/docs/stylelint/integrate-vscode.md
@@ -9,11 +9,11 @@ meta:
 
 [Stylelint VS Code extension](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) greatly improves the development experience by **automatically linting** the code as you type and **automatically formatting** the code according to your Stylelint configuration whenever you save.
 
-## 1. Install the Stylelint extension
+## Install Stylelint extension
 
 Open VS Code and install the [stylelint.vscode-stylelint](https://marketplace.visualstudio.com/items?stylelint.vscode-stylelint.vscode-eslint) extension.
 
-## 2. Configure VS Code
+## Configure VS Code
 
 Then, add the following settings to your solution [VS Code settings file](https://code.visualstudio.com/docs/getstarted/settings):
 
@@ -28,10 +28,10 @@ Then, add the following settings to your solution [VS Code settings file](https:
 }
 ```
 
-## 3. Install the EditorConfig extension
+## Install EditorConfig extension
 
 Finally, install the [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) extension.
 
-## 4. Try it :rocket:
+## Try it :rocket:
 
 Restart VS Code, open a CSS file, type invalid code in a CSS selector (e.g. `color: #fff`), then save. The code should have been formatted automatically (e.g. `color: #ffffff`).

--- a/docs/stylelint/setup-monorepo-2.md
+++ b/docs/stylelint/setup-monorepo-2.md
@@ -1,8 +1,10 @@
 ---
 order: 90
-label: Setup a monorepo
+label: Setup a monorepo 2
 meta:
     title: Setup a monorepo - Stylelint
+toc:
+    depth: 2-4
 ---
 
 # Setup a monorepo
@@ -13,7 +15,9 @@ This monorepo setup is intended to be used with [PNPM workspaces](https://pnpm.i
 
 To lint a monorepo solution (**multiple projects** per repository), [Stylelint](https://stylelint.io/) must be setuped to lint the files at the root of the solution (the monorepo **workspace**) and the files of every project of the monorepo. Execute the following steps to setup Stylelint for a monorepo solution.
 
-## Install the workspace packages
+## Setup the workspace
+
+### Install the packages
 
 Open a terminal at the root of the solution workspace (the **root** of the repository) and install the following packages:
 
@@ -31,7 +35,7 @@ npm install -D @workleap/stylelint-config stylelint prettier
 ```
 +++
 
-## Configure Stylelint for the workspace
+### Configure Stylelint
 
 First, create a configuration file named `.stylelintrc.json` at the root of the solution workspace:
 
@@ -55,7 +59,7 @@ Then, open the newly created file and extend the default configuration with the 
 }
 ```
 
-## Ignore files
+#### .stylelintignore
 
 Stylelint can be configured to [ignore](https://stylelint.io/user-guide/ignore-code#files-entirely) certain files and directories while linting by specifying one or more glob patterns.
 
@@ -80,7 +84,7 @@ Then, open the newly created file and paste the following ignore rules:
 node_modules
 ```
 
-## Configure Prettier
+#### .prettierignore
 
 Since we choose to [stick with ESLint for JavaScript and JSON stylistic rules](../eslint/default.md#prettier), a `.prettierignore` file must be added at the root of the solution workspace to ignore everything but CSS files.
 
@@ -106,7 +110,7 @@ Then, open the newly created file and paste the following ignore rules:
 !**/*.css
 ```
 
-## Configure indent style
+### Configure the indent style
 
 Prettier offers [built-in rules](https://prettier.io/docs/en/options#tab-width) for configuring the indentation style of a codebase. However, there's a catch: when [VS Code auto-formatting](https://code.visualstudio.com/docs/editor/codebasics#_formatting) feature is enabled, it might conflict with the configured indentation rules if they are set differently.
 
@@ -144,7 +148,7 @@ indent_size = 4
 trim_trailing_whitespace = false
 ```
 
-## Add a CLI script
+### Add a CLI script
 
 At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's workspace `package.json` file:
 
@@ -169,7 +173,9 @@ workspace
 
 > The script definition may vary depending on your needs and your application configuration. For example, you might want to specify additional file extensions such as `"**/*.{css,scss,sass}"`.
 
-## Install the packages for a project
+## Setup a project
+
+### Install the packages
 
 Open a terminal at the root of the project (`packages/app` for this example) and install the following package:
 
@@ -187,7 +193,7 @@ npm install -D @workleap/stylelint-config
 ```
 +++
 
-## Configure Stylelint for the project
+### Configure Stylelint
 
 First, create a configuration file named `.stylelintrc.json` at the root of the project:
 
@@ -214,11 +220,7 @@ Then, open the newly created file and extend the default configuration with the 
 }
 ```
 
-## Repeat for every project
-
-If you have multiple projects in your monorepo solution, repeat the steps [#7](#install-the-packages-for-a-project) and [#8](#configure-stylelint-for-the-project) for every project.
-
-## Customize configuration
+## Custom configuration
 
 New projects shouldn't have to customize the default configurations offered by `@workleap/stylelint-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
 

--- a/docs/stylelint/setup-polyrepo.md
+++ b/docs/stylelint/setup-polyrepo.md
@@ -9,7 +9,7 @@ meta:
 
 Execute the following steps to setup [Stylelint](https://stylelint.io/) for a polyrepo solution (**single project** per repository).
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the solution and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/stylelint-configs stylelint prettier
 ```
 +++
 
-## 2. Configure Stylelint
+## Configure Stylelint
 
 First, create a configuration file named `.stylelintrc.json` at the root of the solution:
 
@@ -48,7 +48,7 @@ Then, open the newly created file and extend the default configuration with the 
 }
 ```
 
-## 3. Ignore files
+### .stylelintignore
 
 Stylelint can be configured to [ignore](https://stylelint.io/user-guide/ignore-code#files-entirely) certain files and directories while linting by specifying one or more glob patterns.
 
@@ -70,7 +70,7 @@ Then, open the newly created file and paste the following ignore rules:
 node_modules
 ```
 
-## 4. Configure Prettier
+### .prettierignore
 
 Since we choose to [stick with ESLint for JavaScript and JSON stylistic rules](../eslint/default.md#prettier), a `.prettierignore` file must be added at the root of the solution to ignore everything but CSS files.
 
@@ -93,7 +93,7 @@ Then, open the newly created file and paste the following ignore rules:
 !**/*.css
 ```
 
-## 5. Configure indent style
+## Configure indent style
 
 Prettier offers [built-in rules](https://prettier.io/docs/en/options#tab-width) for configuring the indentation style of a codebase. However, there's a catch: when [VS Code auto-formatting](https://code.visualstudio.com/docs/editor/codebasics#_formatting) feature is enabled, it might conflict with the configured indentation rules if they are set  differently.
 
@@ -131,7 +131,7 @@ trim_trailing_whitespace = false
 
 Finally, install the [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) VS Code extension.
 
-## 6. Add a CLI script
+## Add a CLI script
 
 At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's `package.json` file:
 
@@ -143,13 +143,13 @@ At times, especially when running the CI build, it's useful to lint the entire s
 
 > The script definition may vary depending on your needs and your application configuration. For example, you might want to specify additional file extensions such as `"**/*.{css,scss,sass}"`.
 
-## 7. Customize configuration
+## Custom configuration
 
 New projects shouldn't have to customize the default configurations offered by `@workleap/stylelint-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
 
-## 8. Try it :rocket:
+## Try it :rocket:
 
-To test your new setup, open a CSS file, type invalid code (e.g. `color: #fff`), then save. Open a terminal at the root of the solution and execute the [CLI script added earlier](#6-add-a-cli-script):
+To test your new setup, open a CSS file, type invalid code (e.g. `color: #fff`), then save. Open a terminal at the root of the solution and execute the [CLI script added earlier](#add-a-cli-script):
 
 +++ pnpm
 ```bash

--- a/docs/swc/configure-build.md
+++ b/docs/swc/configure-build.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [SWC](https://swc.rs/) for a production environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/swc-configs @swc/core @swc/helpers
 ```
 +++
 
-## 2. Configure SWC
+## Configure SWC
 
 First, create a configuration file named `swc.build.js` at the root of the project:
 
@@ -99,7 +99,7 @@ The `browserslistToSwc(options)` utility function accepts any option supported b
 
 - `queries`: `string | string[]`
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineBuildConfig(targets, options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
@@ -122,13 +122,13 @@ export const swcConfig = defineBuildConfig(targets, {
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default build configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/build.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default build configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/build.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `defineBuildConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default development configuration of `@workleap/swc-configs`, have a look at the [build.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/build.ts) on GitHub.
 
@@ -177,7 +177,7 @@ export const transformer: SwcConfigTransformer = (config: SwcConfig, context: Sw
 
 - `environment`: `"dev" | "build" | "jest"`
 
-## 5. Configure webpack
+## Configure webpack
 
 To integrate with webpack, update your configuration file to include an [swc-loader](https://swc.rs/docs/usage/swc-loader):
 
@@ -203,7 +203,7 @@ export default {
 }
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
 To test your new [SWC](https://swc.rs/) configuration, create a Typescript file with the following code:
 

--- a/docs/swc/configure-dev.md
+++ b/docs/swc/configure-dev.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [SWC](https://swc.rs/) for a development environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/swc-configs @swc/core @swc/helpers
 ```
 +++
 
-## 2. Configure SWC
+## Configure SWC
 
 First, create a configuration file named `swc.dev.js` at the root of the project:
 
@@ -99,7 +99,7 @@ The `browserslistToSwc(options)` utility function accepts any option supported b
 
 - `queries`: `string | string[]`
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineDevConfig(targets, options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
@@ -141,13 +141,13 @@ export const swcConfig = defineDevConfig(targets, {
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/dev.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/dev.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `defineDevConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default development configuration of `@workleap/swc-configs`, have a look at the [dev.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/dev.ts) on GitHub.
 
@@ -196,7 +196,7 @@ export const transformer: SwcConfigTransformer = (config: SwcConfig, context: Sw
 
 - `environment`: `"dev" | "build" | "jest"`
 
-## 5. Configure webpack
+## Configure webpack
 
 To integrate with webpack, update your configuration file to include an [swc-loader](https://swc.rs/docs/usage/swc-loader):
 
@@ -222,7 +222,7 @@ export default {
 }
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
 To test your new SWC configuration, create a Typescript file with the following code:
 

--- a/docs/swc/configure-jest.md
+++ b/docs/swc/configure-jest.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [SWC](https://swc.rs/) for a [Jest](https://jestjs.io/) environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/swc-configs @swc/jest @swc/core @swc/helpers
 ```
 +++
 
-## 2. Configure SWC
+## Configure SWC
 
 !!!info
 To use a TypeScript configuration file, make sure that your Jest configuration is also in TypeScript.
@@ -52,7 +52,7 @@ import { defineJestConfig } from "@workleap/swc-configs";
 export const swcConfig = defineJestConfig();
 ```
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineJestConfig(options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
@@ -86,13 +86,13 @@ export const swcConfig = defineJestConfig({
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/jest.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/jest.ts) of `@workleap/swc-configs`, but only covers a subset of an [SWC configuration](https://swc.rs/docs/configuration/swcrc). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `defineJestConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default Jest configuration of `@workleap/swc-configs`, have a look at the [jest.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/swc-configs/src/jest.ts) on GitHub.
 
@@ -119,7 +119,7 @@ export const swcConfig = defineJestConfig({
 });
 ```
 
-## 5. Configure Jest
+## Configure Jest
 
 To configure Jest, open the project `jest.config.ts` file and add the following code:
 
@@ -133,7 +133,7 @@ const config = {
 };
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
 To test your new SWC configuration, create a Jest test in Typescript:
 

--- a/docs/swc/default.md
+++ b/docs/swc/default.md
@@ -32,7 +32,7 @@ Somewhere in 2024, [we expect to migrate from webpack to Rspack](../webpack/defa
 
 Meanwhile, you can **confidently start a new project with these SWC configurations** as the migration process to Rspack is expected to be seamless.
 
-## Features
+## Main features
 
 The shared configurations offered by `@workleap/swc-configs` includes the following features 👇
 

--- a/docs/tsup/configure-build.md
+++ b/docs/tsup/configure-build.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [tsup](https://tsup.egoist.dev/) for a build environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/tsup-configs tsup typescript
 ```
 +++
 
-## 2. Configure tsup
+## Configure tsup
 
 First, create a configuration file named `tsup.build.ts` at the root of the project:
 
@@ -47,7 +47,7 @@ import { defineBuildConfig } from "@workleap/tsup-configs";
 export default defineBuildConfig();
 ```
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineBuildConfig(options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accepts any [tsup options](https://tsup.egoist.dev/#usage), **no locked in** :heart::v::
 
@@ -59,13 +59,13 @@ export default defineBuildConfig({
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-Since the [predefined options](#3-set-predefined-options) for tsup already covers all the availables [options](https://tsup.egoist.dev/#usage), configuration transformer functions aren't as useful for a tsup configuration as for other tools like [SWC](../swc/configure-build.md#4-transform-configuration) or [webpack](../webpack/configure-build.md#4-transform-configuration). Nonetheless, they are still valuable, especially for library authors aiming to **distribute** a **default option set** that facilitates the configuration of tsup for specific functionalities of their library.
+Since the [predefined options](#use-predefined-options) for tsup already covers all the availables [options](https://tsup.egoist.dev/#usage), configuration transformer functions aren't as useful for a tsup configuration as for other tools like [SWC](../swc/configure-build.md#configuration-transformers) or [webpack](../webpack/configure-build.md#configuration-transformers). Nonetheless, they are still valuable, especially for library authors aiming to **distribute** a **default option set** that facilitates the configuration of tsup for specific functionalities of their library. Configuration transformer functions can be provided through the `transformers` option of the `defineBuildConfig` function.
 
 To view the default build configuration of `@workleap/tsup-configs`, have a look at the [build.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/tsup-configs/src/build.ts) on GitHub.
 
@@ -117,7 +117,7 @@ export const myCustomTsupTransformer: TsupConfigTransformer = (config: TsupConfi
 
 - `environment`: `"dev" | "build"`
 
-## 5. Add a CLI script
+## Add a CLI script
 
 To build the bundle files for production, add the following script to your project `package.json` file:
 
@@ -127,6 +127,6 @@ To build the bundle files for production, add the following script to your proje
 }
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
-To test your new tsup configuration, open a terminal at the root of the project and execute the [CLI script added previously](#5-add-a-cli-script). The build process should complete without outputting any error in the terminal and the bundle files should be available in the `/dist` folder (or any other `outputDir` you configured).
+To test your new tsup configuration, open a terminal at the root of the project and execute the [CLI script added previously](#add-a-cli-script). The build process should complete without outputting any error in the terminal and the bundle files should be available in the `/dist` folder (or any other `outputDir` you configured).

--- a/docs/tsup/configure-dev.md
+++ b/docs/tsup/configure-dev.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [tsup](https://tsup.egoist.dev/) for a development environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/tsup-configs tsup typescript
 ```
 +++
 
-## 2. Configure tsup
+## Configure tsup
 
 First, create a configuration file named `tsup.dev.ts` at the root of the project:
 
@@ -47,7 +47,7 @@ import { defineDevConfig } from "@workleap/tsup-configs";
 export default defineDevConfig();
 ```
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineDevConfig(options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accepts any [tsup options](https://tsup.egoist.dev/#usage), **no locked in** :heart::v::
 
@@ -59,13 +59,13 @@ export default defineDevConfig({
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-Since the [predefined options](#3-set-predefined-options) for tsup already covers all the availables [options](https://tsup.egoist.dev/#usage), configuration transformer functions aren't as useful for a tsup configuration as for other tools like [SWC](../swc/configure-dev.md#4-transform-configuration) or [webpack](../webpack/configure-dev.md#4-transform-configuration). Nonetheless, they are still valuable, especially for library authors aiming to **distribute** a **default option set** that facilitates the configuration of tsup for specific functionalities of their library.
+Since the [predefined options](#use-predefined-options) for tsup already covers all the availables [options](https://tsup.egoist.dev/#usage), configuration transformer functions aren't as useful for a tsup configuration as for other tools like [SWC](../swc/configure-dev.md#configuration-transformers) or [webpack](../webpack/configure-dev.md#configuration-transformers). Nonetheless, they are still valuable, especially for library authors aiming to **distribute** a **default option set** that facilitates the configuration of tsup for specific functionalities of their library. Configuration transformer functions can be provided through the `transformers` option of the `defineDevConfig` function.
 
 To view the default development configuration of `@workleap/tsup-configs`, have a look at the [dev.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/tsup-configs/src/dev.ts) on GitHub.
 
@@ -117,7 +117,7 @@ export const transformer: TsupConfigTransformer = (config: TsupConfig, context: 
 
 - `environment`: `"dev" | "build"`
 
-## 5. Add a CLI script
+## Add a CLI script
 
 To initiate the development process, add the following script to your project `package.json` file:
 
@@ -127,6 +127,6 @@ To initiate the development process, add the following script to your project `p
 }
 ```
 
-## 6. Try it :rocket:
+## Try it :rocket:
 
-To test your new tsup configuration, open a terminal at the root of the project and execute the [CLI script added previously](#5-add-a-cli-script). A development process should start without outputting any error in the terminal.
+To test your new tsup configuration, open a terminal at the root of the project and execute the [CLI script added previously](#add-a-cli-script). A development process should start without outputting any error in the terminal.

--- a/docs/tsup/default.md
+++ b/docs/tsup/default.md
@@ -32,7 +32,7 @@ Out of the box, `tsc`, the native [TypeScript CLI](https://www.typescriptlang.or
 
 Given that either TurboSnap requirements or `tsx` CSS imports support change, we will reevaluate this decision.
 
-## Features
+## Main features
 
 The shared configurations offered by `@workleap/tsup-configs` includes the following features 👇
 

--- a/docs/typescript/setup-monorepo-2.md
+++ b/docs/typescript/setup-monorepo-2.md
@@ -1,0 +1,204 @@
+---
+order: 90
+label: Setup a monorepo 2
+meta:
+    title: Setup a monorepo - TypeScript
+toc:
+    depth: 2-4
+---
+
+# Setup a monorepo
+
+!!!warning
+This monorepo setup is intended to be used with [PNPM workspaces](https://pnpm.io/workspaces). You may need a different setup for [NPM workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) or [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) because by default, those package managers **hoist dependencies** rather than installing them in isolation like PNPM.
+!!!
+
+To lint a monorepo solution (**multiple projects** per repository), [TypeScript](https://www.typescriptlang.org/) must be setuped to lint the files at the root of the solution (the monorepo **workspace**) and the files of every project of the monorepo. Execute the following steps to setup TypeScript for a monorepo solution.
+
+## Setup the workspace
+
+### Install the packages
+
+Open a terminal at the root of the solution workspace (the **root** of the repository) and install the following packages:
+
++++ pnpm
+```bash
+pnpm add -D @workleap/typescript-configs typescript
+```
++++ yarn
+```bash
+yarn add -D @workleap/typescript-configs typescript
+```
++++ npm
+```bash
+npm install -D @workleap/typescript-configs typescript
+```
++++
+
+### Configure TypeScript
+
+First, create a configuration file named `tsconfig.json` at the root of the solution workspace:
+
+``` !#8
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json
+├── tsconfig.json
+```
+
+Then, open the newly created file and extend the default configuration with the `monorepo-workspace` shared configurations:
+
+```json !#2 tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/monorepo-workspace.json",
+    "exclude": ["packages", "node_modules"]
+}
+```
+
+### Add a CLI script
+
+At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's workspace `package.json` file:
+
+``` !#7
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├── package.json    <------- (this one!)
+├── tsconfig.json
+```
+
+```json package.json
+{
+    "lint:types": "pnpm -r --parallel --include-workspace-root exec tsc"
+}
+```
+
+## Setup a project
+
+### Install the package
+
+Open a terminal at the root of the project (`packages/app` for this example) and install the following package:
+
++++ pnpm
+```bash
+pnpm add -D @workleap/typescript-configs typescript
+```
++++ yarn
+```bash
+yarn add -D @workleap/typescript-configs typescript
+```
++++ npm
+```bash
+npm install -D @workleap/typescript-configs typescript
+```
++++
+
+### Configure TypeScript
+
+First, create a configuration file named `tsconfig.json` at the root of the project:
+
+``` !#7
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├────── tsconfig.json
+├── package.json
+├── tsconfig.json
+```
+
+Then, open the newly created file and extend the default configuration with one of the [shared configurations](default.md/#available-configurations) provided by `@workleap/typescript-configs` :point_down:
+
+#### `web-application`
+
+For an applications developed with React, use the following configuration:
+
+```json !#2 tsconfig.json
+{
+    "extends": ["@workleap/typescript-configs/web-application.json"],
+    "exclude": ["dist", "node_modules"]
+}
+```
+
+#### `library`
+
+For a library project developed with or without React, use the following configuration:
+
+```json !#2 tsconfig.json
+{
+    "extends": ["@workleap/typescript-configs/library.json"],
+    "exclude": ["dist", "node_modules"]
+}
+```
+
+## Custom configuration
+
+New projects shouldn't have to customize most of the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
+
+### Compiler paths
+
+If any projects of your solution are referencing other projects of the monorepo workspace (e.g. `"@sample/components": "workspace:*"`), chances are that you'll need to define [paths](https://www.typescriptlang.org/tsconfig#compilerOptions) in their `tsconfig.json` file.
+
+Given the following solution:
+
+``` !#3,8,13
+workspace
+├── packages
+├──── app
+├────── src
+├──────── ...
+├────── package.json
+├────── tsconfig.json
+├──── components (@sample/components)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├──── utils (@sample/utils)
+├────── src
+├──────── index.ts
+├────── package.json
+├────── tsconfig.json
+├── package.json
+├── tsconfig.json
+```
+
+If the `packages/components` project is referencing the `packages/utils` project, and the `packages/app` project is referencing the `packages/components` project, you'll need to add the following `compilerOptions.paths`:
+
+```json !#4-7 packages/app/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/web-application.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/components": ["../components/index.ts"],
+            "@sample/utils": ["../utils/index.ts"]
+        }
+    },
+    "exclude": ["dist", "node_modules"]
+}
+```
+
+```json !#4-6 packages/components/tsconfig.json
+{
+    "extends": "@workleap/typescript-configs/library.json",
+    "compilerOptions": {
+        "paths": {
+            "@sample/utils": ["../utils/index.ts"]
+        }
+    },
+    "exclude": ["dist", "node_modules"]
+}
+```
+
+## Try it :rocket:
+
+To test your new TypeScript setup, open a TypeScript file, type invalid code (e.g. `import { App } from "./App"`), then wait for the IDE to flag the error. Fix the error (e.g. `import { App } from "./App.tsx"`), then wait for the IDE to remove the error.

--- a/docs/typescript/setup-polyrepo.md
+++ b/docs/typescript/setup-polyrepo.md
@@ -9,7 +9,7 @@ meta:
 
 Execute the following steps to setup [TypeScript](https://www.typescriptlang.org/) for a polyrepo solution (**single project** per repository).
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the solution and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/typescript-configs typescript
 ```
 +++
 
-## 2. Configure TypeScript
+## Configure TypeScript
 
 First, create a configuration file named `tsconfig.json` at the root of the solution:
 
@@ -41,7 +41,7 @@ root
 
 Then, open the newly created file and extend the default configuration with one of the [shared configurations](default.md#available-configurations) provided by `@workleap/typescript-configs` :point_down:
 
-### web-application
+### `web-application`
 
 For an applications developed with React, use the following configuration:
 
@@ -52,7 +52,7 @@ For an applications developed with React, use the following configuration:
 }
 ```
 
-### library
+### `library`
 
 For a library project developed with or without React, use the following configuration:
 
@@ -63,7 +63,7 @@ For a library project developed with or without React, use the following configu
 }
 ```
 
-## 3. Add a CLI script
+## Add a CLI script
 
 At times, especially when running the CI build, it's useful to lint the entire solution using a single command. To do so, add the following script to your solution's `package.json` file:
 
@@ -73,10 +73,10 @@ At times, especially when running the CI build, it's useful to lint the entire s
 }
 ```
 
-## 4. Customize configuration
+## Custom configuration
 
 New projects shouldn't have to customize the default configurations offered by `@workleap/typescript-configs`. However, if you are in the process of **migrating** an existing project to use this library or encountering a challenging situation, refer to the [custom configuration](custom-configuration.md) page to understand how to override or extend the default configurations. Remember, **no locked in** :heart::v:.
 
-## 5. Try it :rocket:
+## Try it :rocket:
 
 To test your new TypeScript setup, open a TypeScript file, type invalid code (e.g. `import { App } from "./App"`), then wait for the IDE to flag the error. Fix the error (e.g. `import { App } from "./App.tsx"`), then wait for the IDE to remove the error.

--- a/docs/webpack/configure-build.md
+++ b/docs/webpack/configure-build.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [webpack](https://webpack.js.org/) for a production environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/webpack-configs webpack webpack-cli @swc/core @swc/help
 ```
 +++
 
-## 2. Configure webpack
+## Configure webpack
 
 ### HTML template
 
@@ -58,9 +58,9 @@ Then, open the newly created `index.html` file and copy/paste the following cont
 
 The content of the `public/index.html` file is the default template that will be used by [HtmlWebpackPlugin](https://webpack.js.org/plugins/html-webpack-plugin/).
 
-#### Adding local assets
+#### Reference local assets
 
-To link local assets such as a `favicon.png` in the default HTML template, it is recommended to preprend the **relative** path of every asset with the `publicPath` of the webpack config.
+To reference local assets such as a `favicon.png` in the default HTML template, it is recommended to preprend the **relative** path of every asset with the `publicPath` of the webpack config.
 
 First, add the asset to the `public` folder at the root of the project:
 
@@ -88,7 +88,7 @@ Then, add the assets to the `index.html` file:
 </html>
 ```
 
-### defineBuildConfig
+### `defineBuildConfig`
 
 Next, create a configuration file named `webpack.build.js` at the root of the project:
 
@@ -111,7 +111,7 @@ import { swcConfig } from "./swc.build.js";
 export default defineBuildConfig(swcConfig);
 ```
 
-### swcConfig
+### `swcConfig`
 
 In the previous code sample, the `defineBuildConfig(swcConfig, options)` function receive an SWC [configuration object](https://swc.rs/docs/configuration/swcrc) through the `swcConfig` parameter. 
 
@@ -119,7 +119,7 @@ Although the [swc-loader](https://swc.rs/docs/usage/swc-loader) defaults to load
 
 Therefore, `@workleap/webpack-configs` choosed to **delegate** the loading of the SWC configuration **to the consumer** by making the `swcConfig` option **required**. 
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineBuildConfig(swcConfig, options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
@@ -373,13 +373,13 @@ export default defineDevConfig(swcConfig, {
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default build configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/build.ts) of `@workleap/webpack-configs`, but only covers a subset of a [webpack configuration](https://webpack.js.org/configuration/). If you need full control over the configuration, you can provide configuration transformer functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default build configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/build.ts) of `@workleap/webpack-configs`, but only covers a subset of a [webpack configuration](https://webpack.js.org/configuration/). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `defineBuildConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default build configuration of `@workleap/webpack-configs`, have a look at the [build.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/build.ts) on GitHub.
 
@@ -434,7 +434,7 @@ Modifying a webpack configuration object can be an arduous task, to help with th
 
 [!ref Transformer utilities](transformer-utilities.md)
 
-## 5. Add a CLI script
+## Add a CLI script
 
 To create the bundle files for production, add the following script to your project `package.json` file:
 
@@ -444,7 +444,7 @@ To create the bundle files for production, add the following script to your proj
 }
 ```
 
-## 6. Set environment variables
+## Use environment variables
 
 To deal with environment variables, the webpack documentation suggests using the [--env option](https://webpack.js.org/guides/environment-variables/) from its CLI. While that would work, by using webpack `--env` CLI option, the environment variables would only be made available to the webpack configuration files (.e.g. `webpack.build.js`) rather than any Node.js files. Therefore we **do not recommend** using webpack `--env` CLI option.
 
@@ -511,6 +511,6 @@ export function App() {
 The `=== "true"` part of `"DEBUG": process.env.DEBUG === "true"` is very important, otherwise the environment variable value would be `"true"` instead of `true`.
 !!!
 
-## 7. Try it :rocket:
+## Try it :rocket:
 
-To test your new webpack configuration, open a terminal at the root of the project and execute the [CLI script added earlier](#5-add-a-cli-script). The build process should complete without outputting any error in the terminal and the bundle files should be available in the `/dist` folder (or any other `outputPath` you configured).
+To test your new webpack configuration, open a terminal at the root of the project and execute the [CLI script added earlier](#add-a-cli-script). The build process should complete without outputting any error in the terminal and the bundle files should be available in the `/dist` folder (or any other `outputPath` you configured).

--- a/docs/webpack/configure-dev.md
+++ b/docs/webpack/configure-dev.md
@@ -9,7 +9,7 @@ meta:
 
 To configure [webpack](https://webpack.js.org/) for a development environment, execute the following steps.
 
-## 1. Install the packages
+## Install the packages
 
 Open a terminal at the root of the project and install the following packages:
 
@@ -27,7 +27,7 @@ npm install -D @workleap/webpack-configs webpack webpack-cli webpack-dev-server 
 ```
 +++
 
-## 2. Configure webpack
+## Configure webpack
 
 ### HTML template
 
@@ -57,9 +57,9 @@ Then, open the newly created `index.html` file and copy/paste the following cont
 
 The content of the `public/index.html` file is the default template that will be used by [HtmlWebpackPlugin](https://webpack.js.org/plugins/html-webpack-plugin/).
 
-#### Adding local assets
+#### Reference local assets
 
-To link local assets such as a `favicon.png` in the default HTML template, it is recommended to preprend the **relative** path of every asset with the `publicPath` of the webpack config.
+To reference local assets such as a `favicon.png` in the default HTML template, it is recommended to preprend the **relative** path of every asset with the `publicPath` of the webpack config.
 
 First, add the asset to the `public` folder at the root of the project:
 
@@ -87,7 +87,7 @@ Then, add the assets to the `index.html` file:
 </html>
 ```
 
-### defineDevConfig
+### `defineDevConfig`
 
 Next, create a configuration file named `webpack.dev.js` at the root of the project:
 
@@ -112,7 +112,7 @@ import { swcConfig } from "./swc.dev.js";
 export default defineDevConfig(swcConfig);
 ```
 
-### swcConfig
+### `swcConfig`
 
 In the previous code sample, the `defineDevConfig(swcConfig, options)` function receive an SWC [configuration object](https://swc.rs/docs/configuration/swcrc) through the `swcConfig` parameter. 
 
@@ -120,7 +120,7 @@ Although the [swc-loader](https://swc.rs/docs/usage/swc-loader) defaults to load
 
 Therefore, `@workleap/webpack-configs` choosed to **delegate** the loading of the SWC configuration **to the consumer** by making the `swcConfig` option **required**. 
 
-## 3. Set predefined options
+## Use predefined options
 
 The `defineDevConfig(swcConfig, options)` function can be used as shown in the previous example, however, if you wish to customize the default configuration, the function also accept a few predefined options to help with that 👇
 
@@ -384,13 +384,13 @@ export default defineDevConfig(swcConfig, {
 });
 ```
 
-## 4. Transform configuration
+## Configuration transformers
 
 !!!warning
 We do not guarantee that your configuration transformers won't break after an update. It's your responsibility to keep them up to date with new releases.
 !!!
 
-The [predefined options](#3-set-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/dev.ts) of `@workleap/webpack-configs`, but only covers a subset of a [webpack configuration](https://webpack.js.org/configuration/). If you need full control over the configuration, you can provide configuration transformer functions. Remember, **no locked in** :heart::v:.
+The [predefined options](#use-predefined-options) are useful to quickly customize the [default development configuration](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/dev.ts) of `@workleap/webpack-configs`, but only covers a subset of a [webpack configuration](https://webpack.js.org/configuration/). If you need full control over the configuration, you can provide configuration transformer functions through the `transformers` option of the `defineDevConfig` function. Remember, **no locked in** :heart::v:.
 
 To view the default development configuration of `@workleap/webpack-configs`, have a look at the [dev.ts configuration file](https://github.com/gsoft-inc/wl-web-configs/blob/main/packages/webpack-configs/src/dev.ts) on GitHub.
 
@@ -450,7 +450,7 @@ Modifying a webpack configuration object can be an arduous task, to help with th
 
 [!ref Transformer utilities](transformer-utilities.md)
 
-## 5. Setup nodemon
+## Setup nodemon
 
 [Nodemon](https://nodemon.io/) is a utility that will monitor for any changes in the `swc.dev.js` and `webpack.dev.dev.js` files and restart the webpack development server whenever a change occurs.
 
@@ -476,9 +476,9 @@ Then, open the `nodemon.json` file and copy/paste the following content:
 }
 ```
 
-Finally, add a CLI script at the [next step](#6-add-a-cli-script) of this guide.
+Finally, add a CLI script at the [next step](#add-a-cli-script) of this guide.
 
-## 6. Add a CLI script
+## Add a CLI script
 
 To initiate the development server, add the following script to your project `package.json` file:
 
@@ -488,7 +488,7 @@ To initiate the development server, add the following script to your project `pa
 }
 ```
 
-## 7. Set environment variables
+## Define environment variables
 
 To deal with environment variables, the webpack documentation suggests using the [--env option](https://webpack.js.org/guides/environment-variables/) from its CLI. While that would work, by using webpack `--env` CLI option, the environment variables would only be made available to the webpack configuration files (.e.g. `webpack.dev.js`) rather than any Node.js files. Therefore we **do not recommend** using webpack `--env` CLI option.
 
@@ -555,8 +555,8 @@ export function App() {
 The `=== "true"` part of `"DEBUG": process.env.DEBUG === "true"` is very important, otherwise the environment variable value would be `"true"` instead of `true`.
 !!!
 
-## 8. Try it :rocket:
+## Try it :rocket:
 
-To test your new webpack configuration, open a terminal at the root of the project and execute the [CLI script added earlier](#6-add-a-cli-script). A development server should start without outputting any error in the terminal.
+To test your new webpack configuration, open a terminal at the root of the project and execute the [CLI script added earlier](#add-a-cli-script). A development server should start without outputting any error in the terminal.
 
 

--- a/docs/webpack/default.md
+++ b/docs/webpack/default.md
@@ -32,7 +32,7 @@ npm create @workleap/project@latest <output-directory>
 
 Meanwhile, you can **confidently start a new project with webpack** as the **migration** process to Rspack is expected to be **seamless**; Rspack is committed to support the full webpack API and its massive plugin ecosystem.
 
-## Features
+## Main features
 
 The shared configurations offered by `@workleap/webpack-configs` includes the following features :point_down:
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -62,7 +62,7 @@
         }
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@types/eslint": "8.44.2",

--- a/packages/postcss-configs/package.json
+++ b/packages/postcss-configs/package.json
@@ -38,7 +38,7 @@
         "postcss": ">=8.4.6"
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@types/jest": "29.5.5",

--- a/packages/swc-configs/package.json
+++ b/packages/swc-configs/package.json
@@ -35,7 +35,7 @@
         "build": "tsup"
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@types/jest": "29.5.5",

--- a/packages/swc-configs/src/build.ts
+++ b/packages/swc-configs/src/build.ts
@@ -42,9 +42,7 @@ export function defineBuildConfig(targets: Record<string, string>, options: Defi
         },
         module: {
             // The output module resolution system that the code will be compiled for.
-            type: "es6",
-            // Preserve dynamic imports.
-            ignoreDynamic: true
+            type: "es6"
         },
         env: {
             // jsc.target is not provided because the provided targets takes precedence.

--- a/packages/swc-configs/src/build.ts
+++ b/packages/swc-configs/src/build.ts
@@ -43,8 +43,6 @@ export function defineBuildConfig(targets: Record<string, string>, options: Defi
         module: {
             // The output module resolution system that the code will be compiled for.
             type: "es6",
-            // Prevent SWC from exporting the `__esModule` property.
-            strict: true,
             // Preserve dynamic imports.
             ignoreDynamic: true
         },

--- a/packages/swc-configs/src/dev.ts
+++ b/packages/swc-configs/src/dev.ts
@@ -27,7 +27,7 @@ export function defineDevConfig(targets: Record<string, string>, options: Define
                 },
             transform: {
                 react: {
-                // Use "react/jsx-runtime".
+                    // Use "react/jsx-runtime".
                     runtime: "automatic",
                     // Use the native "Object.assign()" instead of "_extends".
                     useBuiltins: true,
@@ -43,8 +43,6 @@ export function defineDevConfig(targets: Record<string, string>, options: Define
         module: {
             // The output module resolution system that the code will be compiled for.
             type: "es6",
-            // Prevent SWC from exporting the `__esModule` property.
-            strict: true,
             // Preserve dynamic imports.
             ignoreDynamic: true
         },

--- a/packages/swc-configs/src/dev.ts
+++ b/packages/swc-configs/src/dev.ts
@@ -42,9 +42,7 @@ export function defineDevConfig(targets: Record<string, string>, options: Define
         },
         module: {
             // The output module resolution system that the code will be compiled for.
-            type: "es6",
-            // Preserve dynamic imports.
-            ignoreDynamic: true
+            type: "es6"
         },
         env: {
             // jsc.target is not provided because the provided targets takes precedence.

--- a/packages/swc-configs/src/jest.ts
+++ b/packages/swc-configs/src/jest.ts
@@ -41,8 +41,6 @@ export function defineJestConfig(options: DefineJestConfigOptions = {}) {
         module: {
             // The output module resolution system that the code will be compiled for.
             type: "es6",
-            // Prevent SWC from exporting the `__esModule` property.
-            strict: true,
             // Preserve dynamic imports.
             ignoreDynamic: true
         }

--- a/packages/swc-configs/src/jest.ts
+++ b/packages/swc-configs/src/jest.ts
@@ -40,9 +40,7 @@ export function defineJestConfig(options: DefineJestConfigOptions = {}) {
         },
         module: {
             // The output module resolution system that the code will be compiled for.
-            type: "es6",
-            // Preserve dynamic imports.
-            ignoreDynamic: true
+            type: "es6"
         }
     };
 

--- a/packages/tsup-configs/package.json
+++ b/packages/tsup-configs/package.json
@@ -40,7 +40,7 @@
         "typescript": "*"
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@types/jest": "29.5.5",

--- a/packages/webpack-configs/package.json
+++ b/packages/webpack-configs/package.json
@@ -55,7 +55,7 @@
         }
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@types/jest": "29.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 15.10.3(typescript@5.2.2)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -58,7 +58,7 @@ importers:
         version: link:../typescript-configs
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
 
   packages/eslint-plugin:
     dependencies:
@@ -91,14 +91,14 @@ importers:
         version: 6.0.1(eslint@8.49.0)(typescript@5.2.2)
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@types/eslint':
         specifier: 8.44.2
         version: 8.44.2
@@ -131,10 +131,10 @@ importers:
         version: 29.7.0(@types/node@20.6.2)(ts-node@10.9.1)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -149,14 +149,14 @@ importers:
         version: 9.1.3(postcss@8.4.29)
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -183,10 +183,10 @@ importers:
         version: 8.4.29
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -220,7 +220,7 @@ importers:
         version: 15.10.3(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -228,14 +228,14 @@ importers:
   packages/swc-configs:
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -256,10 +256,10 @@ importers:
         version: 29.7.0(@types/node@20.6.2)(ts-node@10.9.1)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -267,14 +267,14 @@ importers:
   packages/tsup-configs:
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -292,10 +292,10 @@ importers:
         version: 29.7.0(@types/node@20.6.2)(ts-node@10.9.1)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -331,20 +331,20 @@ importers:
         version: 3.3.3(webpack@5.88.2)
       swc-loader:
         specifier: 0.2.3
-        version: 0.2.3(@swc/core@1.3.84)(webpack@5.88.2)
+        version: 0.2.3(@swc/core@1.3.85)(webpack@5.88.2)
       terser-webpack-plugin:
         specifier: 5.3.9
-        version: 5.3.9(@swc/core@1.3.84)(esbuild@0.18.20)(webpack@5.88.2)
+        version: 5.3.9(@swc/core@1.3.85)(esbuild@0.18.20)(webpack@5.88.2)
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@types/jest':
         specifier: 29.5.5
         version: 29.5.5
@@ -377,16 +377,16 @@ importers:
         version: 4.0.1(postcss@8.4.29)(ts-node@10.9.1)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+        version: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
       webpack:
         specifier: 5.88.2
-        version: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+        version: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
       webpack-dev-server:
         specifier: 4.15.1
         version: 4.15.1(webpack@5.88.2)
@@ -413,14 +413,14 @@ importers:
         specifier: 8.1.0
         version: 8.1.0(typescript@5.2.2)
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/helpers':
         specifier: 0.5.2
         version: 0.5.2
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@testing-library/react':
         specifier: 14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -495,7 +495,7 @@ importers:
         version: 5.2.2
       webpack:
         specifier: 5.88.2
-        version: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+        version: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: 5.1.4
         version: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
@@ -506,11 +506,11 @@ importers:
   sample/components:
     devDependencies:
       '@swc/core':
-        specifier: 1.3.84
-        version: 1.3.84(@swc/helpers@0.5.2)
+        specifier: 1.3.85
+        version: 1.3.85(@swc/helpers@0.5.2)
       '@swc/jest':
         specifier: 0.2.29
-        version: 0.2.29(@swc/core@1.3.84)
+        version: 0.2.29(@swc/core@1.3.85)
       '@testing-library/react':
         specifier: 14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
@@ -555,7 +555,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -573,7 +573,7 @@ importers:
         version: link:../../packages/typescript-configs
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
+        version: 7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -2943,7 +2943,7 @@ packages:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
       webpack-dev-server: 4.15.1(webpack@5.88.2)
     dev: false
 
@@ -3114,88 +3114,88 @@ packages:
       - supports-color
       - typescript
 
-  /@swc/core-darwin-arm64@1.3.84:
-    resolution: {integrity: sha512-mqK0buOo+toF2HoJ/gWj2ApZbvbIiNq3mMwSTHCYJHlQFQfoTWnl9aaD5GSO4wfNFVYfEZ1R259o5uv5NlVtoA==}
+  /@swc/core-darwin-arm64@1.3.85:
+    resolution: {integrity: sha512-jTikp+i4nO4Ofe6qGm4I3sFeebD1OvueBCHITux5tQKD6umN1c2z4CRGv6K49NIz/qEpUcdr6Qny6K+3yibVFQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@swc/core-darwin-x64@1.3.84:
-    resolution: {integrity: sha512-cyuQZz62C43EDZqtnptUTlfDvAjgG3qu139m5zsfIK6ltXA5inKFbDWV3a/M5c18dFzA2Xh21Q46XZezmtQ9Tg==}
+  /@swc/core-darwin-x64@1.3.85:
+    resolution: {integrity: sha512-3uHYkjVU+2F+YbVYtq5rH0uCJIztFTALaS3mQEfQUZKXZ5/8jD5titTCRqFKtSlQg0CzaFZgsYsuqwYBmgN0mA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@swc/core-linux-arm-gnueabihf@1.3.84:
-    resolution: {integrity: sha512-dmt/ECQrp3ZPWnK27p4E4xRIRHOoJhgGvxC5t5YaWzN20KcxE9ykEY2oLGSoeceM/A+4D11aRYGwF/EM7yOkvA==}
+  /@swc/core-linux-arm-gnueabihf@1.3.85:
+    resolution: {integrity: sha512-ouHzAHsFaEOkRuoTAOI/8n2m8BQAAnb4vr/xbMhhDOmix0lp5eNsW5Iac/EcJ2uG6B3n7P2K8oycj9SWkj+pfw==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.3.84:
-    resolution: {integrity: sha512-PgVfrI3NVg2z/oeg3GWLb9rFLMqidbdPwVH5nRyHVP2RX/BWP6qfnYfG+gJv4qrKzIldb9TyCGH7y8VWctKLxw==}
+  /@swc/core-linux-arm64-gnu@1.3.85:
+    resolution: {integrity: sha512-/Z1CZOWiO+NqJEh1J20PIxQFHMH43upQJ1l7FJ5Z7+MyuYF8WkeJ7OSovau729pBR+38vvvccEJrMZIztfv7hQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.3.84:
-    resolution: {integrity: sha512-hcuEa8/vin4Ns0P+FpcDHQ4f3jmhgGKQhqw0w+TovPSVTIXr+nrFQ2AGhs9nAxS6tSQ77C53Eb5YRpK8ToFo1A==}
+  /@swc/core-linux-arm64-musl@1.3.85:
+    resolution: {integrity: sha512-gfh7CfKavi076dbMBTzfdawSGcYfZ4+1Q+8aRkSesqepKHcIWIJti8Cf3zB4a6CHNhJe+VN0Gb7DEfumydAm1w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.3.84:
-    resolution: {integrity: sha512-IvyimSbwGdu21jBBEqR1Up8Jhvl8kIAf1k3e5Oy8oRfgojdUfmW1EIwgGdoUeyQ1VHlfquiWaRGfsnHQUKl35g==}
+  /@swc/core-linux-x64-gnu@1.3.85:
+    resolution: {integrity: sha512-lWVqjHKzofb9q1qrBM4dLqO7CIisp08/xMS5Hz9DWex1gTc5F2b6yJO6Ceqwa256GMweJcdP6A5EvEFQAiZ5dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@swc/core-linux-x64-musl@1.3.84:
-    resolution: {integrity: sha512-hdgVU/O5ufDCe+p5RtCjU7PRNwd0WM+eWJS+GNY4QWL6O8y2VLM+i4+6YzwSUjeBk0xd+1YElMxbqz7r5tSZhw==}
+  /@swc/core-linux-x64-musl@1.3.85:
+    resolution: {integrity: sha512-EPJmlfqC05TUetnlErxNRyIp7Nc3B2w9abET6oQ/EgldeAeQnZ3M6svMViET/c2QSomgrU3rdP+Qcozkt62/4A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.3.84:
-    resolution: {integrity: sha512-rzH6k2BF0BFOFhUTD+bh0oCiUCZjFfDfoZoYNN/CM0qbtjAcFH21hzMh/EH8ZaXq8k/iQmUNNa5MPNPZ4SOMNw==}
+  /@swc/core-win32-arm64-msvc@1.3.85:
+    resolution: {integrity: sha512-ibckJDZw8kNosciMexwk0z75ZyUhwtiFMV9rSBpup0opa7NNCUCoERCJ1e9LRyMdhsVUoLpZg/KZiHCdTw96hQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.3.84:
-    resolution: {integrity: sha512-Y+Dk7VLLVwwsAzoDmjkNW/sTmSPl9PGr4Mj1nhc5A2NNxZ+hz4SxFMclacDI03SC5ikK8Qh6WOoE/+nwUDa3uA==}
+  /@swc/core-win32-ia32-msvc@1.3.85:
+    resolution: {integrity: sha512-hY4MpHGUVQHL1T2kgRXOigDho4DTIpVPYzJ4uyy8VQRbS7GzN5XtvdGP/fA4zp8+2BQjcig+6J7Y92SY15ouNQ==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.3.84:
-    resolution: {integrity: sha512-WmpaosqCWMX7DArLdU8AJcj96hy0PKlYh1DaMVikSrrDHbJm2dZ8rd27IK3qUB8DgPkrDYHmLAKNZ+z3gWXgRQ==}
+  /@swc/core-win32-x64-msvc@1.3.85:
+    resolution: {integrity: sha512-ktxWOMFJ0iqKn6WUHtXqi4CS7xkyHmrRtjllGRuGqxmLmDX/HSOfuQ55Tm1KXKk5oHLacJkUbOSF2kBrpZ8dpg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
 
-  /@swc/core@1.3.84(@swc/helpers@0.5.2):
-    resolution: {integrity: sha512-UPKUiDwG7HOdPfOb1VFeEJ76JDgU2w80JLewzx6tb0fk9TIjhr9yxKBzPbzc/QpjGHDu5iaEuNeZcu27u4j63g==}
+  /@swc/core@1.3.85(@swc/helpers@0.5.2):
+    resolution: {integrity: sha512-qnoxp+2O0GtvRdYnXgR1v8J7iymGGYpx6f6yCK9KxipOZOjrlKILFANYlghQxZyPUfXwK++TFxfSlX4r9wK+kg==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -3207,38 +3207,38 @@ packages:
       '@swc/helpers': 0.5.2
       '@swc/types': 0.1.4
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.84
-      '@swc/core-darwin-x64': 1.3.84
-      '@swc/core-linux-arm-gnueabihf': 1.3.84
-      '@swc/core-linux-arm64-gnu': 1.3.84
-      '@swc/core-linux-arm64-musl': 1.3.84
-      '@swc/core-linux-x64-gnu': 1.3.84
-      '@swc/core-linux-x64-musl': 1.3.84
-      '@swc/core-win32-arm64-msvc': 1.3.84
-      '@swc/core-win32-ia32-msvc': 1.3.84
-      '@swc/core-win32-x64-msvc': 1.3.84
+      '@swc/core-darwin-arm64': 1.3.85
+      '@swc/core-darwin-x64': 1.3.85
+      '@swc/core-linux-arm-gnueabihf': 1.3.85
+      '@swc/core-linux-arm64-gnu': 1.3.85
+      '@swc/core-linux-arm64-musl': 1.3.85
+      '@swc/core-linux-x64-gnu': 1.3.85
+      '@swc/core-linux-x64-musl': 1.3.85
+      '@swc/core-win32-arm64-msvc': 1.3.85
+      '@swc/core-win32-ia32-msvc': 1.3.85
+      '@swc/core-win32-x64-msvc': 1.3.85
 
   /@swc/helpers@0.5.2:
     resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
     dependencies:
       tslib: 2.6.2
 
-  /@swc/jest@0.2.29(@swc/core@1.3.84):
+  /@swc/jest@0.2.29(@swc/core@1.3.85):
     resolution: {integrity: sha512-8reh5RvHBsSikDC3WGCd5ZTd2BXKkyOdK7QwynrCH58jk2cQFhhHhFBg/jvnWZehUQe/EoOImLENc9/DwbBFow==}
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
     dependencies:
       '@jest/create-cache-key-function': 27.5.1
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
       jsonc-parser: 3.2.0
     dev: true
 
   /@swc/types@0.1.4:
     resolution: {integrity: sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==}
 
-  /@testing-library/dom@9.3.1:
-    resolution: {integrity: sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==}
+  /@testing-library/dom@9.3.3:
+    resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.22.13
@@ -3259,7 +3259,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.22.15
-      '@testing-library/dom': 9.3.1
+      '@testing-library/dom': 9.3.3
       '@types/react-dom': 18.2.7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -3882,7 +3882,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
     dev: true
 
@@ -3893,7 +3893,7 @@ packages:
       webpack: 5.x.x
       webpack-cli: 5.x.x
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
     dev: true
 
@@ -3908,7 +3908,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.2)
     dev: true
@@ -4946,7 +4946,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.29)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     dev: false
 
   /css-prefers-color-scheme@9.0.0(postcss@8.4.29):
@@ -6532,7 +6532,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     dev: false
 
   /htmlparser2@6.1.0:
@@ -7275,7 +7275,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8425,7 +8425,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     dev: false
 
   /minimalistic-assert@1.0.1:
@@ -9207,7 +9207,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.29
-      ts-node: 10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2)
       yaml: 2.3.2
 
   /postcss-loader@7.3.3(postcss@8.4.29)(typescript@5.2.2)(webpack@5.88.2):
@@ -9221,7 +9221,7 @@ packages:
       jiti: 1.20.0
       postcss: 8.4.29
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -10465,7 +10465,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     dev: false
 
   /style-search@0.1.0:
@@ -10617,14 +10617,14 @@ packages:
       csso: 5.0.5
       picocolors: 1.0.0
 
-  /swc-loader@0.2.3(@swc/core@1.3.84)(webpack@5.88.2):
+  /swc-loader@0.2.3(@swc/core@1.3.85)(webpack@5.88.2):
     resolution: {integrity: sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==}
     peerDependencies:
       '@swc/core': ^1.2.147
       webpack: '>=2'
     dependencies:
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
     dev: false
 
   /symbol-tree@3.2.4:
@@ -10658,7 +10658,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.84)(esbuild@0.18.20)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.85)(esbuild@0.18.20)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10675,15 +10675,15 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.19
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
       esbuild: 0.18.20
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.84)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.85)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10700,12 +10700,12 @@ packages:
         optional: true
     dependencies:
       '@jridgewell/trace-mapping': 0.3.19
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
     dev: true
 
   /terser@5.19.4:
@@ -10888,7 +10888,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.84)(@types/node@20.6.2)(typescript@5.2.2):
+  /ts-node@10.9.1(@swc/core@1.3.85)(@types/node@20.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -10903,7 +10903,7 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -10935,7 +10935,7 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.2.0(@swc/core@1.3.84)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2):
+  /tsup@7.2.0(@swc/core@1.3.85)(postcss@8.4.29)(ts-node@10.9.1)(typescript@5.2.2):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}
     engines: {node: '>=16.14'}
     hasBin: true
@@ -10951,7 +10951,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/core': 1.3.84(@swc/helpers@0.5.2)
+      '@swc/core': 1.3.85(@swc/helpers@0.5.2)
       bundle-require: 4.0.1(esbuild@0.18.20)
       cac: 6.7.14
       chokidar: 3.5.3
@@ -11455,7 +11455,7 @@ packages:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.88.2)
       webpack-merge: 5.9.0
     dev: true
@@ -11471,7 +11471,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
 
   /webpack-dev-server@4.15.1(webpack-cli@5.1.4)(webpack@5.88.2):
     resolution: {integrity: sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==}
@@ -11514,7 +11514,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4)
+      webpack: 5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
       webpack-dev-middleware: 5.3.3(webpack@5.88.2)
       ws: 8.14.1
@@ -11566,7 +11566,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.88.2(@swc/core@1.3.84)(esbuild@0.18.20)
+      webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.20)
       webpack-dev-middleware: 5.3.3(webpack@5.88.2)
       ws: 8.14.1
     transitivePeerDependencies:
@@ -11587,7 +11587,7 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
-  /webpack@5.88.2(@swc/core@1.3.84)(esbuild@0.18.20):
+  /webpack@5.88.2(@swc/core@1.3.85)(esbuild@0.18.20):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -11618,7 +11618,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.84)(esbuild@0.18.20)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.18.20)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -11626,7 +11626,7 @@ packages:
       - esbuild
       - uglify-js
 
-  /webpack@5.88.2(@swc/core@1.3.84)(webpack-cli@5.1.4):
+  /webpack@5.88.2(@swc/core@1.3.85)(webpack-cli@5.1.4):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -11657,7 +11657,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.84)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-cli: 5.1.4(webpack-dev-server@4.15.1)(webpack@5.88.2)
       webpack-sources: 3.2.3

--- a/sample/app/package.json
+++ b/sample/app/package.json
@@ -20,7 +20,7 @@
     },
     "devDependencies": {
         "@svgr/webpack": "8.1.0",
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/helpers": "0.5.2",
         "@swc/jest": "0.2.29",
         "@testing-library/react": "14.0.0",

--- a/sample/components/package.json
+++ b/sample/components/package.json
@@ -28,7 +28,7 @@
         "react-dom": "*"
     },
     "devDependencies": {
-        "@swc/core": "1.3.84",
+        "@swc/core": "1.3.85",
         "@swc/jest": "0.2.29",
         "@testing-library/react": "14.0.0",
         "@types/jest": "29.5.5",


### PR DESCRIPTION
- For ESM, SWC v1.3.85 `strict` and `ignoreDynamic` options are no longuer supported.
- Many documentation improvements