### PR TITLE
feat: Allow publicPath auto

### DIFF
--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -49,7 +49,7 @@ export function defineMiniCssExtractPluginConfig(options: MiniCssExtractPluginOp
 
 function preflight(options: DefineBuildConfigOptions) {
     if (options.publicPath) {
-        if (!options.publicPath.endsWith("/") || options.publicPath === "auto") {
+        if (options.publicPath !== "auto" && !options.publicPath.endsWith("/")) {
             throw new Error("[webpack-configs] The \"publicPath\" must end with a \"/\".");
         }
     }

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -49,7 +49,7 @@ export function defineMiniCssExtractPluginConfig(options: MiniCssExtractPluginOp
 
 function preflight(options: DefineBuildConfigOptions) {
     if (options.publicPath) {
-        if (!options.publicPath.endsWith("/")) {
+        if (!options.publicPath.endsWith("/") || options.publicPath === "auto") {
             throw new Error("[webpack-configs] The \"publicPath\" must end with a \"/\".");
         }
     }
@@ -58,7 +58,7 @@ function preflight(options: DefineBuildConfigOptions) {
 export interface DefineBuildConfigOptions {
     entry?: string;
     outputPath?: string;
-    publicPath?: string;
+    publicPath?: `${string}/` | "auto";
     cache?: boolean;
     cacheDirectory?: string;
     moduleRules?: NonNullable<WebpackConfig["module"]>["rules"];

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -32,6 +32,10 @@ test("when a public path not ending with a trailing slash is provided, throw an 
     expect(() => defineBuildConfig(SwcConfig, { publicPath: "an-invalid-public-path" })).toThrow();
 });
 
+test("when a public path is set to \"auto\", should not throw an error", () => {
+    expect(() => defineBuildConfig(SwcConfig, { publicPath: "auto" })).not.toThrow();
+});
+
 test("when a valid public path is provided, use the provided public path value", () => {
     const result = defineBuildConfig(SwcConfig, {
         publicPath: "a-valid-public-path-ending-with-a-trailing-slash/"

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -27,6 +27,8 @@ test("when an output path is provided, use the provided ouput path value", () =>
 });
 
 test("when a public path not ending with a trailing slash is provided, throw an error", () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - We know this is invalid, but we still want to test the error.
     expect(() => defineBuildConfig(SwcConfig, { publicPath: "an-invalid-public-path" })).toThrow();
 });
 


### PR DESCRIPTION
Closes #158

- Modified the  `preflight` function to allow publicPath value `"auto"`
- Modified the type of `publicPath` to enforce a leading slash, instead of only enforcing it at runtime.