### PR TITLE
chore: multiple fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ pnpm install
 
 ### Setup Retype
 
-[Retype](https://retype.com/) is the documentation platform that `workleap/web-configs` is using for the documentation. As this project is leveraging a few [Pro features](https://retype.com/pro/) of Retype, you must first setup your [Retype wallet](https://retype.com/guides/cli/#retype-wallet).
+[Retype](https://retype.com/) is the documentation platform that `workleap/web-configs` is using for its documentation. As this project is leveraging a few [Pro features](https://retype.com/pro/) of Retype.
+
+Everything should work fine as-is but there are a few limitations to use Retype Pro features without a wallet with a licence. If you want to circumvent these limitations, you can optionally, setup your [Retype wallet](https://retype.com/guides/cli/#retype-wallet).
 
 To do so, first make sure that you retrieve the Retype license from your Vault (or ask IT).
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Common configurations for building web apps at [Workleap](https://workleap.com/)
 | --- | --- |
 | [@workleap/browserslist-config](packages/browserslist-config/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/browserslist-config)](https://www.npmjs.com/package/@workleap/browserslist-config) |
 | [@workleap/eslint-plugin](packages/eslint-plugin/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/eslint-plugin)](https://www.npmjs.com/package/@workleap/eslint-plugin) |
-| [@workleap/postcss-plugin](packages/postcss-plugin/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/postcss-plugin)](https://www.npmjs.com/package/@workleap/postcss-plugin) |
+| [@workleap/postcss-configs](packages/postcss-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/postcss-configs)](https://www.npmjs.com/package/@workleap/postcss-configs) |
 | [@workleap/stylelint-plugin](packages/stylelint-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/stylelint-configs)](https://www.npmjs.com/package/@workleap/stylelint-configs) |
-| [@workleap/typescript-config](packages/typescript-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/typescript-configs)](https://www.npmjs.com/package/@workleap/typescript-configs) |
+| [@workleap/typescript-configs](packages/typescript-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/typescript-configs)](https://www.npmjs.com/package/@workleap/typescript-configs) |
 | [@workleap/tsup-configs](packages/tsup-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/tsup-configs)](https://www.npmjs.com/package/@workleap/tsup-configs) |
 | [@workleap/swc-configs](packages/swc-configs/README.md) | [![npm version](https://img.shields.io/npm/v/@workleap/swc-configs)](https://www.npmjs.com/package/@workleap/swc-configs) |
 

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -23,6 +23,11 @@ const __filename = fileURLToPath(import.meta.url);
 
 type MiniCssExtractPluginOptions = NonNullable<ConstructorParameters<typeof MiniCssExtractPlugin>[number]>;
 
+// export interface OptimizeOptions {
+//     minimize?: boolean;
+//     chunkIds?: NonNullable<WebpackConfig["optimization"]>["chunkIds"];
+// }
+
 export function defineBuildHtmlWebpackPluginConfig(options: HtmlWebpackPlugin.Options = {}): HtmlWebpackPlugin.Options {
     const {
         template = path.resolve("./public/index.html"),
@@ -152,7 +157,12 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
             : {
                 minimize: false,
                 chunkIds: "named",
-                moduleIds: "named"
+                concatenateModules: false,
+                flagIncludedChunks: false,
+                mangleExports: false,
+                mangleWasmImports: false,
+                moduleIds: "named",
+                removeAvailableModules: false
             },
         infrastructureLogging: verbose ? {
             appendOnly: true,

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -52,14 +52,6 @@ export function defineMiniCssExtractPluginConfig(options: MiniCssExtractPluginOp
     };
 }
 
-function preflight(options: DefineBuildConfigOptions) {
-    if (options.publicPath) {
-        if (options.publicPath !== "auto" && !options.publicPath.endsWith("/")) {
-            throw new Error("[webpack-configs] The \"publicPath\" must end with a \"/\".");
-        }
-    }
-}
-
 export interface DefineBuildConfigOptions {
     entry?: string;
     outputPath?: string;
@@ -78,8 +70,6 @@ export interface DefineBuildConfigOptions {
 }
 
 export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConfigOptions = {}) {
-    preflight(options);
-
     const {
         entry = path.resolve("./src/index.tsx"),
         outputPath = path.resolve("dist"),

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -23,11 +23,6 @@ const __filename = fileURLToPath(import.meta.url);
 
 type MiniCssExtractPluginOptions = NonNullable<ConstructorParameters<typeof MiniCssExtractPlugin>[number]>;
 
-// export interface OptimizeOptions {
-//     minimize?: boolean;
-//     chunkIds?: NonNullable<WebpackConfig["optimization"]>["chunkIds"];
-// }
-
 export function defineBuildHtmlWebpackPluginConfig(options: HtmlWebpackPlugin.Options = {}): HtmlWebpackPlugin.Options {
     const {
         template = path.resolve("./public/index.html"),

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -26,12 +26,6 @@ test("when an output path is provided, use the provided ouput path value", () =>
     expect(result.output?.path).toBe("./a-new-output-path");
 });
 
-test("when a public path not ending with a trailing slash is provided, throw an error", () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - We know this is invalid, but we still want to test the error.
-    expect(() => defineBuildConfig(SwcConfig, { publicPath: "an-invalid-public-path" })).toThrow();
-});
-
 test("when a public path is set to \"auto\", should not throw an error", () => {
     expect(() => defineBuildConfig(SwcConfig, { publicPath: "auto" })).not.toThrow();
 });


### PR DESCRIPTION
# What changed

## @workleap/webpack-configs

- Removed the `build` config `preflight` function because it's not enforced by TypeScript typings.
- Updated the `build` config non-optimized options.