### PR TITLE
Make Webpack RegEx stricter

### DIFF
--- a/.changeset/tough-panthers-do.md
+++ b/.changeset/tough-panthers-do.md
@@ -1,0 +1,5 @@
+---
+"@workleap/webpack-configs": patch
+---
+
+Fix file extension RegEx rules being too lenient

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -157,21 +157,21 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
         module: {
             rules: [
                 {
-                    test: /\.(js|jsx|ts|tsx)/i,
+                    test: /\.(js|jsx|ts|tsx)$/i,
                     exclude: /node_modules/,
                     loader: require.resolve("swc-loader"),
                     options: swcConfig
                 },
                 {
                     // https://stackoverflow.com/questions/69427025/programmatic-webpack-jest-esm-cant-resolve-module-without-js-file-exten
-                    test: /\.js/i,
+                    test: /\.js$/i,
                     include: /node_modules/,
                     resolve: {
                         fullySpecified: false
                     }
                 },
                 {
-                    test: /\.css/i,
+                    test: /\.css$/i,
                     use: [
                         { loader: MiniCssExtractPlugin.loader },
                         {
@@ -188,11 +188,11 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
                     ]
                 },
                 {
-                    test: /\.svg/i,
+                    test: /\.svg$/i,
                     loader: require.resolve("@svgr/webpack")
                 },
                 {
-                    test: /\.(png|jpe?g|gif)/i,
+                    test: /\.(png|jpe?g|gif)$/i,
                     type: "asset/resource"
                 },
                 ...moduleRules

--- a/packages/webpack-configs/src/dev.ts
+++ b/packages/webpack-configs/src/dev.ts
@@ -174,21 +174,21 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
         module: {
             rules: [
                 {
-                    test: /\.(js|jsx|ts|tsx)/i,
+                    test: /\.(js|jsx|ts|tsx)$/i,
                     exclude: /node_modules/,
                     loader: require.resolve("swc-loader"),
                     options: trySetSwcFastRefresh(swcConfig, fastRefresh !== false)
                 },
                 {
                     // https://stackoverflow.com/questions/69427025/programmatic-webpack-jest-esm-cant-resolve-module-without-js-file-exten
-                    test: /\.js/i,
+                    test: /\.js$/i,
                     include: /node_modules/,
                     resolve: {
                         fullySpecified: false
                     }
                 },
                 {
-                    test: /\.css/i,
+                    test: /\.css$/i,
                     use: [
                         { loader: require.resolve("style-loader") },
                         {
@@ -205,11 +205,11 @@ export function defineDevConfig(swcConfig: SwcConfig, options: DefineDevConfigOp
                     ]
                 },
                 {
-                    test: /\.svg/i,
+                    test: /\.svg$/i,
                     loader: require.resolve("@svgr/webpack")
                 },
                 {
-                    test: /\.(png|jpe?g|gif)/i,
+                    test: /\.(png|jpe?g|gif)$/i,
                     type: "asset/resource"
                 },
                 ...moduleRules


### PR DESCRIPTION
Closes #166

**Changes:**

- Add the end-of-string `$` token to the different Webpack RegEx. This helps us make sure we're targeting the extension, and solves the issue of `.json` files being recognized as a `.js` file.