### PR TITLE
fix: Fixed tsup entry option

### DIFF
--- a/.changeset/early-lemons-develop.md
+++ b/.changeset/early-lemons-develop.md
@@ -1,0 +1,5 @@
+---
+"@workleap/tsup-configs": patch
+---
+
+Excluding tests files and stories files from TSUP bundles.

--- a/packages/tsup-configs/src/build.ts
+++ b/packages/tsup-configs/src/build.ts
@@ -15,7 +15,11 @@ export function defineBuildConfig(options: DefineBuildConfigOptions = {}) {
         clean: true,
         dts: true,
         treeshake: true,
-        entry: ["./src"],
+        entry: [
+            "./src",
+            "!src/**/*.stories.ts(x)",
+            "!src/**/*.test.ts(x)"
+        ],
         outDir: "./dist",
         format: "esm",
         target: "esnext",

--- a/packages/tsup-configs/src/dev.ts
+++ b/packages/tsup-configs/src/dev.ts
@@ -14,7 +14,11 @@ export function defineDevConfig(options: DefineDevConfigOptions = {}) {
     const config: TsupConfig = {
         dts: true,
         watch: true,
-        entry: ["./src"],
+        entry: [
+            "./src",
+            "!src/**/*.stories.ts(x)",
+            "!src/**/*.test.ts(x)"
+        ],
         outDir: "./dist",
         format: "esm",
         target: "esnext",


### PR DESCRIPTION
The TSUP configs were including test files and stories files into the compiled bundle. These changes make sure to stop including those files.