### PR TITLE
Feat: Fix error when user navigates after a deployment

### DIFF
--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -34,7 +34,7 @@ type MiniCssExtractPluginOptions = NonNullable<ConstructorParameters<typeof Mini
 
 export function defineMiniCssExtractPluginConfig(options: MiniCssExtractPluginOptions = {}): MiniCssExtractPluginOptions {
     const {
-        filename = "[name].[fullhash].css",
+        filename = "[name].css",
         ...rest
     } = options;
 
@@ -141,7 +141,7 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
         entry,
         output: {
             path: outputPath,
-            filename: "[name].[fullhash].js",
+            filename: "[name].js",
             publicPath,
             clean: true
         },

--- a/packages/webpack-configs/src/build.ts
+++ b/packages/webpack-configs/src/build.ts
@@ -143,7 +143,8 @@ export function defineBuildConfig(swcConfig: SwcConfig, options: DefineBuildConf
             path: outputPath,
             filename: "[name].js",
             publicPath,
-            clean: true
+            clean: true,
+            assetModuleFilename: "[name][ext][query]"
         },
         optimization: getOptimizationConfig(optimize),
         infrastructureLogging: verbose ? {

--- a/packages/webpack-configs/tests/build.test.ts
+++ b/packages/webpack-configs/tests/build.test.ts
@@ -354,7 +354,7 @@ describe("defineMiniCssExtractPluginConfig", () => {
         });
 
         expect(result.chunkFilename).toBe("a-custom-chunk-filename");
-        expect(result.filename).toBe("[name].[fullhash].css");
+        expect(result.filename).toBe("[name].css");
     });
 
 


### PR DESCRIPTION
If a user is on the site when a deployment happens, they will get an error if they try to load a chunk (navigate to a route) that hadn't previously been fetched. This is because index.html hasn't been refreshed, and will attempt to fetch a chunk that no longer exists. This change will allow the user to fetch the new chunk immediately, or continue using the old chunk (if it has been cached in the browser) until they refresh. Refreshing will fetch all chunks again as needed.

The behavior is due to the hash inserted into the file name, causing the file name to change on every deployment. My tests show that this cache-busting hash isn't necessary. I tested the solution with basic default cache control headers (max age=60 minutes) as well as directly on Netlify (max age=0 minutes, force revalidate). If the file changes, the CDN will respond with the updated copy, even if the file name is the same and even if you are below the max-age. If it hasn't changed, the CDN sends a 304 and the browser uses its cached version.