### PR TITLE
EP-8886: Update Stylelint config to allow the use of dynamic viewport units

### DIFF
--- a/.changeset/real-stamps-watch.md
+++ b/.changeset/real-stamps-watch.md
@@ -1,0 +1,5 @@
+---
+"@workleap/stylelint-configs": patch
+---
+
+Allow the use of dynamic viewport units

--- a/packages/stylelint-configs/src/index.ts
+++ b/packages/stylelint-configs/src/index.ts
@@ -63,6 +63,8 @@ const config: Config = {
             "deg",
             "vh",
             "vw",
+            "dvh",
+            "dvw",
             "s",
             "ch"
             // px is not allowed because we use rem units instead.


### PR DESCRIPTION
Jira issue link: [EP-8886](https://workleap.atlassian.net/browse/EP-8886)

Related to a Hopper bug (https://github.com/workleap/wl-hopper/pull/856), we should use dynamic viewport units when styling things based on screen size to prevent overflows.

Adds `dvh` and `dvw` to the `unit-allowed-list`

[EP-8886]: https://workleap.atlassian.net/browse/EP-8886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ