### PR TITLE
chore: update Retype GitHub Action

### DIFF
--- a/.github/workflows/retype-action.yml
+++ b/.github/workflows/retype-action.yml
@@ -1,6 +1,6 @@
 name: Publish documentation website to GitHub Pages
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
   push:
     branches: ["main"]
 
@@ -14,16 +14,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+        - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 9.0.x
+        - uses: retypeapp/action-build@latest
+          env:
+              RETYPE_KEY: ${{ secrets.RETYPE_API_KEY }}
 
-      - uses: retypeapp/action-build@next
-        with:
-            license: ${{ secrets.RETYPE_API_KEY }}
-
-      - uses: retypeapp/action-github-pages@latest
-        with:
-          update-branch: true
+        - uses: retypeapp/action-github-pages@latest
+          with:
+            update-branch: true


### PR DESCRIPTION
## Summary
- Remove `actions/setup-dotnet` step (no longer needed)
- Switch from `with: license` to `env: RETYPE_KEY` for providing the Retype API key
- Use `retypeapp/action-build@latest` instead of `@next`

Reference: https://retype.com/guides/github-actions/