### PR TITLE
chore: update @typescript/native-preview to version 7.0.0-dev.20260303.1 across all packages and samples

### DIFF
--- a/agent-skills/workleap-skill-safety-review/SKILL.md
+++ b/agent-skills/workleap-skill-safety-review/SKILL.md
@@ -6,6 +6,7 @@ description: >
   (2) Auditing skills for security risks or reviewing PRs that add/update skill dependencies,
   (3) Building a team/org allowlist of approved skills,
   (4) Investigating suspicious skill behavior or answering "is this skill safe?" / "should we adopt this skill?"
+disable-model-invocation: true
 metadata:
   version: 1.3
 ---

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "@eslint/js": "9.39.2",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",
         "agent-browser": "0.15.2",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -35,7 +35,7 @@
     "devDependencies": {
         "@eslint/js": "9.39.2",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "eslint": "9.39.2",
         "rimraf": "6.1.3",

--- a/packages/eslint-configs/package.json
+++ b/packages/eslint-configs/package.json
@@ -77,7 +77,7 @@
         "@types/eslint-plugin-jsx-a11y": "6.10.1",
         "@types/estree": "1.0.8",
         "@types/node": "25.3.3",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/typescript-configs": "workspace:*",
         "eslint": "9.39.2",
         "typescript": "5.9.3",

--- a/packages/postcss-configs/package.json
+++ b/packages/postcss-configs/package.json
@@ -45,7 +45,7 @@
         "@rslib/core": "0.19.6",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",

--- a/packages/rsbuild-configs/package.json
+++ b/packages/rsbuild-configs/package.json
@@ -50,7 +50,7 @@
         "@rspack/core": "1.7.7",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",

--- a/packages/rslib-configs/package.json
+++ b/packages/rslib-configs/package.json
@@ -45,7 +45,7 @@
         "@rslib/core": "0.19.6",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",
         "eslint": "9.39.2",

--- a/packages/stylelint-configs/package.json
+++ b/packages/stylelint-configs/package.json
@@ -52,7 +52,7 @@
         "@eslint/js": "9.39.2",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",
         "eslint": "9.39.2",

--- a/packages/swc-configs/package.json
+++ b/packages/swc-configs/package.json
@@ -59,7 +59,7 @@
         "@rslib/core": "0.19.6",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",

--- a/packages/tsup-configs/package.json
+++ b/packages/tsup-configs/package.json
@@ -42,7 +42,7 @@
         "@rsbuild/core": "1.7.3",
         "@rslib/core": "0.19.6",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",

--- a/packages/webpack-configs/package.json
+++ b/packages/webpack-configs/package.json
@@ -65,7 +65,7 @@
         "@svgr/core": "8.1.0",
         "@types/node": "25.3.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/swc-configs": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:packages/eslint-configs
@@ -72,8 +72,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -146,7 +146,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@types/eslint-plugin-jsx-a11y':
         specifier: 6.10.1
         version: 6.10.1(jiti@2.6.1)
@@ -157,8 +157,8 @@ importers:
         specifier: 25.3.3
         version: 25.3.3
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/typescript-configs':
         specifier: workspace:*
         version: link:../typescript-configs
@@ -189,7 +189,7 @@ importers:
         version: 9.39.2
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -197,8 +197,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -244,7 +244,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@rspack/core':
         specifier: 1.7.7
         version: 1.7.7(@swc/helpers@0.5.19)
@@ -255,8 +255,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -293,7 +293,7 @@ importers:
         version: 9.39.2
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -301,8 +301,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -341,8 +341,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -391,7 +391,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@types/node':
         specifier: 25.3.3
         version: 25.3.3
@@ -399,8 +399,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -437,13 +437,13 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -531,7 +531,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@svgr/core':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -542,8 +542,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../eslint-configs
@@ -612,8 +612,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@vitejs/plugin-react':
         specifier: 5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
@@ -697,8 +697,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@vitejs/plugin-react':
         specifier: 5.1.4
         version: 5.1.4(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
@@ -746,13 +746,13 @@ importers:
         version: 9.39.2
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../../../packages/eslint-configs
@@ -809,8 +809,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/browserslist-config':
         specifier: workspace:*
         version: link:../../../packages/browserslist-config
@@ -862,7 +862,7 @@ importers:
         version: 1.7.3
       '@rslib/core':
         specifier: 0.19.6
-        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+        version: 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       '@storybook/addon-a11y':
         specifier: 10.2.14
         version: 10.2.14(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -879,8 +879,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/browserslist-config':
         specifier: workspace:*
         version: link:../../../packages/browserslist-config
@@ -907,7 +907,7 @@ importers:
         version: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: 3.3.0
-        version: 3.3.0(@rsbuild/core@1.7.3)(@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3))(storybook-builder-rsbuild@3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)))(typescript@5.9.3)
+        version: 3.3.0(@rsbuild/core@1.7.3)(@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3))(storybook-builder-rsbuild@3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)))(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: 3.3.0
         version: 3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))(webpack@5.105.3)
@@ -967,8 +967,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/browserslist-config':
         specifier: workspace:*
         version: link:../../../packages/browserslist-config
@@ -1072,8 +1072,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../../../packages/eslint-configs
@@ -1129,8 +1129,8 @@ importers:
         specifier: 8.56.1
         version: 8.56.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260209.1
-        version: 7.0.0-dev.20260209.1
+        specifier: 7.0.0-dev.20260303.1
+        version: 7.0.0-dev.20260303.1
       '@workleap/eslint-configs':
         specifier: workspace:*
         version: link:../../../packages/eslint-configs
@@ -4847,43 +4847,43 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-TyFP7dGMo/Xz37MI3QNfGl3J2i8AKurYwLLD+bG0EDLWnz213wwBwN6U9vMcyatBzfdxKEHHPgdNP0UYCVx3kQ==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-jIIQWmFi0bJY4ML8/7eyz1EGpkI6E0R1E5l4lxJdV/orpMr91vYfAajKICs7DUiMGEJX9HpeiA6TD2piw4DKPQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-1Dr8toDQcmqKjXd5cQoTAjzMR46cscaojQiazbAPJsU/1PQFgBT36/Mb/epLpzN+ZKKgf7Xd6u2eqH2ze0kF6Q==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-UkaK+J3f185VXBiAGNG4UKHjGzn4R/nhAz5tArnCKHnIUI7rEnsIm4Xlo5YwmgIATFMU1sVwWUwRshVkMVeFAw==}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-xmGrxP0ERLeczerjJtask6gOln/QhAeELqTmaNoATvU7hZfEzDDxJOgSXZnX6bCIQHdN/Xn49gsyPjzTaK4rAg==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-ELJSV2Q4/mK+ampttssOl4H9s9ZBCc3k7y/u5ivJX8TdlMvZuH/JHqI6cS4Y00flt0R5wc70X+Nlcor4I4+rpw==}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-svmoHHjs5gDekSDW6yLzk9iyDxhMnLKJZ9Xk6b1bSz0swrQNPPTJdR7mbhVMrv4HtXei0LHPlXdTr85AqI5qOQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-H84jTRYqUfc/vhuVGQ6VKcBvJoZ4YmomWDx9U4uwYgW6eoUcRpDXqv3S3YqcNJcUmz22d/tTwIYz8ssXNLa/Qw==}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-cK4XK3L7TXPj9fIalQcXRqSErdM+pZSqiNgp6QtNsNCyoH2W6J281hnjUA4TmD4TRMSn8CRn7Exy3CGNC3gZkA==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-HkddFrPJ0jcrohe+HnCqVTv8PunjqNs7FisRmtIAnc36+ccraDB6MVFEdPyAIL3PUID+TP/ESquqeKNnB7HdrQ==}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-U919FWN5FZG/1i75+Cv9mnd80Mw2rdFE/to/wJ6DX9m0dUL8IfZARQYPGDXDO1LEC6sV3CyCpCJ/HqsSkqgaAg==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-kTTMrBpWuxbHPt9hAFQSWeP//5Oa0KOdAEvceOfXUJhTS8RAA/kZSlFGE/Zw1EtrFLQx2J7uTHUZnYxH1hYXNw==}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-1U/2fG/A1yZtkP59IkDlOVLw2cPtP6NbLROtTytNN0CLSqme+0OXoh+l7wlN2iSmGY5zIeaVcqs4UIL0SiQInQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-UcVZbf4pra46Yx/eFV6m9F+awvihliPEud4Rq+A8Q3q3zI67VRaNH6R2/qeo4AqqKRahmiEdLM6Tnm+gPtLRQQ==}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260209.1':
-    resolution: {integrity: sha512-UdA8RC9ic/qi9ajolQQP7ZG8YwtUbxtTMu6FxKBn4pYWicuXqMjzXqH/Ng+VlqqeYrl088P4Ou0erGPuLu4ajw==}
+  '@typescript/native-preview@7.0.0-dev.20260303.1':
+    resolution: {integrity: sha512-BDHJjXlPldInEogbzAc7OCLvT75p3rdkmb5YIA6Je0vjg+5z1UQp3moAvcBGvZQflO/gusOd9a74EfrMVUU/4g==}
     hasBin: true
 
   '@ungap/structured-clone@1.3.0':
@@ -15477,10 +15477,10 @@ snapshots:
       - tslib
       - typescript
 
-  '@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)':
+  '@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)':
     dependencies:
       '@rsbuild/core': 1.7.3
-      rsbuild-plugin-dts: 0.19.6(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.19.6(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16181,36 +16181,36 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260209.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260303.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260209.1':
+  '@typescript/native-preview@7.0.0-dev.20260303.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260209.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260209.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260303.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260303.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -22479,12 +22479,12 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.19.6(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3):
+  rsbuild-plugin-dts@0.19.6(@rsbuild/core@1.7.3)(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.7.3
     optionalDependencies:
-      '@typescript/native-preview': 7.0.0-dev.20260209.1
+      '@typescript/native-preview': 7.0.0-dev.20260303.1
       typescript: 5.9.3
 
   rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@1.7.3):
@@ -22940,10 +22940,10 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-rslib@3.3.0(@rsbuild/core@1.7.3)(@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3))(storybook-builder-rsbuild@3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)))(typescript@5.9.3):
+  storybook-addon-rslib@3.3.0(@rsbuild/core@1.7.3)(@rslib/core@0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3))(storybook-builder-rsbuild@3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)))(typescript@5.9.3):
     dependencies:
       '@rsbuild/core': 1.7.3
-      '@rslib/core': 0.19.6(@typescript/native-preview@7.0.0-dev.20260209.1)(typescript@5.9.3)
+      '@rslib/core': 0.19.6(@typescript/native-preview@7.0.0-dev.20260303.1)(typescript@5.9.3)
       storybook-builder-rsbuild: 3.3.0(@rsbuild/core@1.7.3)(@rspack/core@1.7.7(@swc/helpers@0.5.19))(msw@2.12.10(@types/node@25.3.3)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(tslib@2.8.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
     optionalDependencies:
       typescript: 5.9.3

--- a/samples/rsbuild/app/package.json
+++ b/samples/rsbuild/app/package.json
@@ -36,7 +36,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@vitejs/plugin-react": "5.1.4",
         "@workleap/browserslist-config": "workspace:*",
         "@workleap/eslint-configs": "workspace:*",

--- a/samples/rsbuild/components/package.json
+++ b/samples/rsbuild/components/package.json
@@ -27,7 +27,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@vitejs/plugin-react": "5.1.4",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/stylelint-configs": "workspace:*",

--- a/samples/rsbuild/rslib-lib/package.json
+++ b/samples/rsbuild/rslib-lib/package.json
@@ -27,7 +27,7 @@
         "@eslint/js": "9.39.2",
         "@rslib/core": "0.19.6",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",

--- a/samples/storybook/rsbuild/package.json
+++ b/samples/storybook/rsbuild/package.json
@@ -25,7 +25,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/browserslist-config": "workspace:*",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rsbuild-configs": "workspace:*",

--- a/samples/storybook/rslib/package.json
+++ b/samples/storybook/rslib/package.json
@@ -24,7 +24,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/browserslist-config": "workspace:*",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/rslib-configs": "workspace:*",

--- a/samples/webpack/app/package.json
+++ b/samples/webpack/app/package.json
@@ -37,7 +37,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/browserslist-config": "workspace:*",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/postcss-configs": "workspace:*",

--- a/samples/webpack/app/src/env.d.ts
+++ b/samples/webpack/app/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}

--- a/samples/webpack/components/package.json
+++ b/samples/webpack/components/package.json
@@ -29,7 +29,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/stylelint-configs": "workspace:*",
         "@workleap/swc-configs": "workspace:*",

--- a/samples/webpack/components/src/env.d.ts
+++ b/samples/webpack/components/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css" {}

--- a/samples/webpack/tsup-lib/package.json
+++ b/samples/webpack/tsup-lib/package.json
@@ -26,7 +26,7 @@
     "devDependencies": {
         "@eslint/js": "9.39.2",
         "@typescript-eslint/parser": "8.56.1",
-        "@typescript/native-preview": "7.0.0-dev.20260209.1",
+        "@typescript/native-preview": "7.0.0-dev.20260303.1",
         "@workleap/eslint-configs": "workspace:*",
         "@workleap/tsup-configs": "workspace:*",
         "@workleap/typescript-configs": "workspace:*",


### PR DESCRIPTION
Fix https://github.com/workleap/wl-web-configs/issues/396

- Updated package.json files in stylelint-configs, swc-configs, tsup-configs, webpack-configs, and pnpm-lock.yaml to use the new version of @typescript/native-preview.
- Updated package.json files in samples for rsbuild app, components, rslib-lib, storybook, and webpack to reflect the new version.
- Added env.d.ts files in webpack app and components to declare module "*.css".