### PR TITLE
feat: upgrade to Rsbuild 2.0 and Rspack 2.0

### DIFF
--- a/.changeset/nice-sails-teach.md
+++ b/.changeset/nice-sails-teach.md
@@ -1,0 +1,5 @@
+---
+"@workleap/rsbuild-configs": patch
+---
+
+(Should have been 4.0.0 my bad) - Update the package configurations and API to match the new Rsbuild 2.0 features / improvements / deprecation.

--- a/.changeset/rsbuild-v2-options.md
+++ b/.changeset/rsbuild-v2-options.md
@@ -1,0 +1,13 @@
+---
+"@workleap/rsbuild-configs": minor
+---
+
+Add new options aligned with [Rsbuild 2.0](https://rsbuild.rs/blog/v2-0):
+
+- New `polyfill` option on `defineBuildConfig`. Defaults to `"usage"`. `core-js` is now declared as a direct dependency of `@workleap/rsbuild-configs` to preserve out-of-the-box polyfill support after Rsbuild 2.0 stopped installing it by default.
+- New `splitChunks` option on `defineBuildConfig`. Defaults to `{ preset: "per-package", chunks: "all" }`, replacing the deprecated `performance.chunkSplit`. Each npm package is now emitted in its own chunk for better long-term caching.
+- New `setup` option on `defineDevConfig`, exposing Rsbuild's `server.setup` hook.
+
+Internal refactor of `getOptimizationConfig` to use Rsbuild's `output.minify` shape. The user-facing `optimize` and `minify` options behave identically.
+
+A new [Migrate to v2.0](https://workleap.github.io/wl-web-configs/rsbuild/migrate-to-v2/) page is available in the documentation.

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -45,10 +45,10 @@ jobs:
           # Using SHA will usually provide cache hit on subsequent commits in a PR
           # but will not provide cache hits between PRs, meaning the first run of a PR
           # will usually only be cache misses.
-          key: ${{ runner.os }}-turbo-changeset-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-changeset-v11-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-changeset-
-            ${{ runner.os }}-turbo-
+            ${{ runner.os }}-turbo-changeset-v11-
+            ${{ runner.os }}-turbo-v11-
           path: .turbo
 
       - name: Build packages

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,10 +50,10 @@ jobs:
         id: cache-turborepo-restore
         uses: actions/cache/restore@v5
         with:
-          key: ${{ runner.os }}-turbo-claude-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-claude-v11-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-claude-
-            ${{ runner.os }}-turbo-
+            ${{ runner.os }}-turbo-claude-v11-
+            ${{ runner.os }}-turbo-v11-
           path: .turbo
 
       - name: Run Claude

--- a/.github/workflows/pr-pkg.yml
+++ b/.github/workflows/pr-pkg.yml
@@ -46,10 +46,10 @@ jobs:
           # Using SHA will usually provide cache hit on subsequent commits in a PR
           # but will not provide cache hits between PRs, meaning the first run of a PR
           # will usually only be cache misses.
-          key: ${{ runner.os }}-turbo-pr-pkg-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-pr-pkg-v11-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-pr-pkg-
-            ${{ runner.os }}-turbo-
+            ${{ runner.os }}-turbo-pr-pkg-v11-
+            ${{ runner.os }}-turbo-v11-
           path: .turbo
 
       - name: Build packages

--- a/docs/rsbuild/configure-build.md
+++ b/docs/rsbuild/configure-build.md
@@ -308,6 +308,57 @@ export default defineBuildConfig({
 });
 ```
 
+### `polyfill`
+
+- **Type**: `"entry"` | `"usage"` | `"off"`
+- **Default**: `"usage"`
+
+Set Rsbuild [output.polyfill](https://rsbuild.dev/config/output/polyfill) option.
+
+`@workleap/rsbuild-configs` bundles [core-js](https://github.com/zloirock/core-js) so polyfills work out of the box. By default, Rsbuild injects polyfills based on actual API usage, which keeps the bundle small while still meeting the Browserslist targets.
+
+```ts !#4 rsbuild.build.ts
+import { defineBuildConfig } from "@workleap/rsbuild-configs";
+
+export default defineBuildConfig({
+    polyfill: "off"
+});
+```
+
+!!!info
+Starting with [Rsbuild 2.0](https://rsbuild.rs/blog/v2-0), `core-js` is no longer installed by default. `@workleap/rsbuild-configs` keeps the previous behavior by depending on `core-js` directly so applications continue to be polyfilled out of the box.
+!!!
+
+### `splitChunks`
+
+- **Type**: An object literal accepting any [splitChunks](https://rsbuild.rs/config/split-chunks) options, or `false`
+- **Default**: `{ preset: "per-package", chunks: "all" }`
+
+Set Rsbuild [splitChunks](https://rsbuild.rs/config/split-chunks) option. By default, every npm package is split into its own chunk, which maximizes long-term caching: rebuilding the application only invalidates the chunks of the packages that actually changed.
+
+To disable code splitting, set the option to `false`:
+
+```ts !#4 rsbuild.build.ts
+import { defineBuildConfig } from "@workleap/rsbuild-configs";
+
+export default defineBuildConfig({
+    splitChunks: false
+});
+```
+
+To customize the strategy, provide a configuration object:
+
+```ts !#4-7 rsbuild.build.ts
+import { defineBuildConfig } from "@workleap/rsbuild-configs";
+
+export default defineBuildConfig({
+    splitChunks: {
+        preset: "single-vendor",
+        chunks: "all"
+    }
+});
+```
+
 ### `react`
 
 - **Type**: `false` or `(defaultOptions: PluginReactOptions) => PluginReactOptions`

--- a/docs/rsbuild/configure-dev.md
+++ b/docs/rsbuild/configure-dev.md
@@ -405,6 +405,28 @@ export default defineDevConfig({
 });
 ```
 
+### `setup`
+
+- **Type**: `ServerSetupFn | ServerSetupFn[]`
+- **Default**: `undefined`
+
+Set Rsbuild [server.setup](https://rsbuild.rs/config/server/setup) hook to run logic when the dev server starts. This is useful for registering custom middleware or running pre-start tasks. The hook can return a callback that runs *after* Rsbuild's default middleware are registered.
+
+```ts !#4-11 rsbuild.dev.ts
+import { defineDevConfig } from "@workleap/rsbuild-configs";
+
+export default defineDevConfig({
+    setup: ({ server, action }) => {
+        if (action === "dev") {
+            server.middlewares.use((req, res, next) => {
+                console.log("dev middleware");
+                next();
+            });
+        }
+    }
+});
+```
+
 ### `react`
 
 - **Type**: `false` or `(defaultOptions: PluginReactOptions) => PluginReactOptions`

--- a/docs/rsbuild/configure-storybook.md
+++ b/docs/rsbuild/configure-storybook.md
@@ -102,9 +102,9 @@ export default defineStorybookConfig({
 ### `lazyCompilation`
 
 - **Type**: `boolean`
-- **Default**: `false`
+- **Default**: `true`
 
-Whether or not to use [lazy compilation](https://rsbuild.dev/config/dev/lazy-compilation). To enable lazy compilation, set the option to `true`.
+Whether or not to use [lazy compilation](https://rsbuild.dev/config/dev/lazy-compilation). To disable lazy compilation, set the option to `false`.
 
 ```ts !#4 rsbuild.dev.ts
 import { defineStorybookConfig } from "@workleap/rsbuild-configs";

--- a/docs/rsbuild/migrate-to-v2.md
+++ b/docs/rsbuild/migrate-to-v2.md
@@ -1,0 +1,160 @@
+---
+order: 40
+label: Migrate to Rsbuild v2.0
+meta:
+    title: Migrate to Rsbuild v2.0
+toc:
+    depth: 2-3
+---
+
+# Migrate to Rsbuild v2.0
+
+`@workleap/rsbuild-configs` v4.0 upgrades to [Rsbuild 2.0](https://rsbuild.rs/blog/v2-0) and [Rspack 2.0](https://www.rspack.dev/blog/announcing-2-0). The upgrade is designed to be mostly transparent, but a few defaults and dependencies changed upstream. This page summarizes what is required to migrate an existing application.
+
+## Update the packages
+
+Open a terminal at the root of the web application project and upgrade the following packages:
+
+```bash
+pnpm add -D @workleap/rsbuild-configs@^4.0.0 @rsbuild/core@^2.0.0 @rspack/core@^2.0.0
+```
+
+## Bump Node.js
+
+Rsbuild 2.0 requires **Node.js `20.19+` or `22.12+`**. Node.js 18 is no longer supported because it reached end of life in April 2025.
+
+Make sure your CI runners and local development environment are running a supported version. The recommended pattern is to pin a version in the project [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) (or equivalent) file:
+
+```text .nvmrc
+22
+```
+
+## Review changed defaults
+
+The following defaults changed upstream. Most projects don't need to react to them, but they're worth knowing about.
+
+### Browserslist targets
+
+The default Rsbuild target versions have been raised:
+
+| Browser   | v1 default | v2 default |
+| --------- | ---------- | ---------- |
+| Chrome    | 87         | 107        |
+| Firefox   | 78         | 104        |
+| Safari    | 14         | 16         |
+| Node.js   | 16         | 20         |
+
+This only matters if your project does **not** ship a [`.browserslistrc`](./configure-build.md#browserslist). Workleap projects following the [getting started](./getting-started.md) guide already extend `@workleap/browserslist-config`, which keeps targets explicit.
+
+### `server.host`
+
+`server.host` now defaults to `'localhost'` (it was `'0.0.0.0'` in v1). `@workleap/rsbuild-configs` already defaulted to `'localhost'` in `defineDevConfig`, so there is no behavior change for Workleap consumers.
+
+### Decorators
+
+The default decorator proposal version moved from `'2022-03'` to `'2023-11'`. If your codebase relies on the older proposal, override it via the [`source.decorators`](https://rsbuild.rs/config/source/decorators) option through a transformer.
+
+### Pure ESM `@rsbuild/core`
+
+`@rsbuild/core` is now published as pure ESM. Node.js 20+ supports loading ESM modules through `require()`, so this is transparent for most projects. If you import `@rsbuild/core` from a CommonJS file, consider migrating that file to ESM.
+
+### Node.js output
+
+When building libraries for Node.js with `@rsbuild/core`, the output is now unminified ESM by default (previously minified CommonJS). This does not affect web applications.
+
+## Verify `core-js` is no longer required as a direct dependency
+
+Rsbuild 2.0 [no longer installs](https://rsbuild.rs/blog/v2-0) `core-js` by default. To keep polyfills working out of the box, `@workleap/rsbuild-configs` now declares `core-js` as a **direct dependency** and the new [`polyfill`](./configure-build.md#polyfill) option defaults to `"usage"`.
+
+You can safely remove `core-js` from your application `package.json` if it was added previously:
+
+```bash
+pnpm remove core-js
+```
+
+If you previously disabled polyfilling through a transformer, you can now do it through the [`polyfill`](./configure-build.md#polyfill) option:
+
+```ts !#4 rsbuild.build.ts
+import { defineBuildConfig } from "@workleap/rsbuild-configs";
+
+export default defineBuildConfig({
+    polyfill: "off"
+});
+```
+
+## Review code splitting
+
+The deprecated `performance.chunkSplit` option has been superseded by the new top-level [`splitChunks`](https://rsbuild.rs/config/split-chunks) option, which aligns with Rspack's native API and adds built-in presets.
+
+`@workleap/rsbuild-configs` exposes the new [`splitChunks`](./configure-build.md#splitchunks) option and defaults it to `{ preset: "per-package", chunks: "all" }`. This splits every npm package into its own chunk, which maximizes long-term caching: rebuilding the application only invalidates the chunks of the packages that actually changed.
+
+!!!warning
+The new default **may change the layout of your `dist/` folder** compared to v1. The change is generally beneficial (smaller cache invalidation, better HTTP/2 parallelism), but if you've configured downstream caching, prefetching, or service worker logic that depends on specific chunk names, review them after the upgrade.
+!!!
+
+To restore the v1 behavior, opt out of code splitting:
+
+```ts !#4 rsbuild.build.ts
+import { defineBuildConfig } from "@workleap/rsbuild-configs";
+
+export default defineBuildConfig({
+    splitChunks: false
+});
+```
+
+If you previously customized splitting through `performance.chunkSplit` in a transformer, [migrate](https://rsbuild.rs/config/split-chunks) to the new option through the `splitChunks` option.
+
+## Custom dev-server middleware
+
+If your project previously used a transformer to set `server.setupMiddlewares`, consider migrating to the new [`setup`](./configure-dev.md#setup) hook, which is more powerful and runs both during `dev` and `preview`:
+
+```ts !#4-11 rsbuild.dev.ts
+import { defineDevConfig } from "@workleap/rsbuild-configs";
+
+export default defineDevConfig({
+    setup: ({ server, action }) => {
+        if (action === "dev") {
+            server.middlewares.use((req, res, next) => {
+                next();
+            });
+        }
+    }
+});
+```
+
+## Module Federation
+
+`@module-federation/runtime-tools` is no longer transitively installed by `@rsbuild/core`. If your project uses [Module Federation](https://rsbuild.rs/guide/advanced/module-federation), install it explicitly:
+
+```bash
+pnpm add -D @module-federation/runtime-tools
+```
+
+## Updates to `@workleap/rsbuild-configs`
+
+In addition to the upstream changes, `@workleap/rsbuild-configs` introduces the following changes:
+
+### `polyfill` option (new)
+
+See [polyfill](./configure-build.md#polyfill). Defaults to `"usage"`.
+
+### `splitChunks` option (new)
+
+See [splitChunks](./configure-build.md#splitchunks). Defaults to the `"per-package"` preset.
+
+### `setup` option (new)
+
+See [setup](./configure-dev.md#setup). Pass-through to Rsbuild's `server.setup` hook.
+
+### `optimize` and `minify` interaction
+
+The internal [`getOptimizationConfig`](https://github.com/workleap/wl-web-configs/blob/main/packages/rsbuild-configs/src/build.ts) helper was rewritten on top of the new [`output.minify`](https://rsbuild.rs/config/output/minify) object shape. The user-facing [`optimize`](./configure-build.md#optimize) option behaves identically, but the underlying configuration is now produced through `output.minify` and `tools.rspack.optimization` rather than a manually constructed `SwcJsMinimizerRspackPlugin` instance. If you were inspecting `tools.rspack.optimization.minimizer` through a transformer, switch to inspecting `output.minify` instead.
+
+## Try it :rocket:
+
+After upgrading, run the project's build and dev scripts and verify:
+
+- The build completes without errors.
+- The development server starts on `https?://localhost:<port>`.
+- The application still polyfills modern APIs in older browsers (if `polyfill` is left to its default).
+- The application's `dist/` chunk layout is acceptable.

--- a/docs/rslib/migrate-to-v2.md
+++ b/docs/rslib/migrate-to-v2.md
@@ -1,0 +1,78 @@
+---
+order: 40
+label: Migrate to v2.0
+meta:
+    title: Migrate to v2.0 - Rslib
+toc:
+    depth: 2-3
+---
+
+# Migrate to v2.0
+
+`@workleap/rslib-configs` has been updated to track [Rslib `0.21+`](https://github.com/web-infra-dev/rslib/releases), which integrates [Rsbuild 2.0](https://rsbuild.rs/blog/v2-0) and [Rspack 2.0](https://www.rspack.dev/blog/announcing-2-0). Unlike `@workleap/rsbuild-configs`, no public API surface of `@workleap/rslib-configs` changed during this upgrade — most of the migration work is upstream.
+
+This page documents the changes that consumers of `@workleap/rslib-configs` should be aware of. For an exhaustive list of upstream changes, refer to the [Rsbuild 2.0 announcement](https://rsbuild.rs/blog/v2-0) and the [Rslib releases](https://github.com/web-infra-dev/rslib/releases).
+
+## Update the packages
+
+Open a terminal at the root of the library project and upgrade the following packages:
+
+```bash
+pnpm add -D @workleap/rslib-configs @rslib/core@^0.21.0
+```
+
+## Bump Node.js
+
+Rsbuild 2.0 (and therefore Rslib `0.20+`) requires **Node.js `20.19+` or `22.12+`**. Node.js 18 is no longer supported because it reached end of life in April 2025.
+
+Make sure your CI runners and local development environment are running a supported version. The recommended pattern is to pin a version in the project [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) (or equivalent) file:
+
+```text .nvmrc
+22
+```
+
+## Review changed defaults
+
+The following upstream changes may affect a library project.
+
+### Pure ESM `@rsbuild/core`
+
+`@rsbuild/core` is now published as pure ESM. If your library imports `@rsbuild/core` from a CommonJS file, migrate that file to ESM.
+
+### Advanced ESM is now the default
+
+The `experiments.advancedEsm` option is now ignored. The advanced ESM behavior (improved tree-shaking, better interop) is enabled by default in both bundle and bundleless modes. If you previously set `experiments.advancedEsm: true` through a transformer, you can remove it.
+
+### Type renames
+
+`StartServerResult` has been renamed to `StartDevServerResult`. If your code imports this type directly from `@rslib/core`, update the import:
+
+```ts
+- import type { StartServerResult } from "@rslib/core";
++ import type { StartDevServerResult } from "@rslib/core";
+```
+
+### Increased `contenthash` length
+
+The default `contenthash` length increased from 8 to 10 characters. Output filenames such as `index.[contenthash].js` will be slightly longer. This is generally beneficial (reduced collision risk) and should not require any action.
+
+## Updates to `@workleap/rslib-configs`
+
+No public option of [`defineBuildConfig`](./configure-build.md), [`defineDevConfig`](./configure-dev.md), or [`defineStorybookConfig`](./configure-storybook.md) changed in this release. The package continues to expose the same defaults and signature as before.
+
+If you previously customized the library configuration through a [transformer](./configure-build.md#transformers), be aware that:
+
+- The underlying configuration is now produced by Rslib `0.21+` on top of Rsbuild 2.0 and Rspack 2.0.
+- Transformer functions that rely on internal v1 shapes (e.g. inspecting `tools.rspack.optimization.minimizer` instances) may need adjustments. Refer to the Rsbuild [migration guide](https://rsbuild.rs/guide/migration/rsbuild-0-x) for the full list of internal changes.
+
+!!!info
+The [`experiments.exe`](https://rslib.rs) option introduced in Rslib `0.21` for building Node.js single-executable applications is **not** currently exposed by `@workleap/rslib-configs`. If you need it, configure it through a transformer.
+!!!
+
+## Try it :rocket:
+
+After upgrading, run the project's build script and verify:
+
+- The build completes without errors.
+- The output `dist/` directory contains the expected files and TypeScript declarations.
+- Consumers of the library compile and run as expected.

--- a/packages/rsbuild-configs/package.json
+++ b/packages/rsbuild-configs/package.json
@@ -41,7 +41,8 @@
         "@rsbuild/plugin-basic-ssl": "^1.2.2",
         "@rsbuild/plugin-image-compress": "^1.3.3",
         "@rsbuild/plugin-react": "^2.0.0",
-        "@rsbuild/plugin-svgr": "^2.0.2"
+        "@rsbuild/plugin-svgr": "^2.0.2",
+        "core-js": "^3.49.0"
     },
     "devDependencies": {
         "@eslint/js": "9.39.2",

--- a/packages/rsbuild-configs/src/build.ts
+++ b/packages/rsbuild-configs/src/build.ts
@@ -1,8 +1,8 @@
-import { defineConfig, type DistPathConfig, type HtmlConfig, type Minify, type RsbuildConfig, type RsbuildEntry, type RsbuildPlugins, type SourceMap } from "@rsbuild/core";
+import { defineConfig, type DistPathConfig, type HtmlConfig, type Minify, type Polyfill, type RsbuildConfig, type RsbuildEntry, type RsbuildPlugins, type SourceMap, type SplitChunksConfig } from "@rsbuild/core";
 import { pluginImageCompress, type PluginImageCompressOptions } from "@rsbuild/plugin-image-compress";
 import { pluginReact, type PluginReactOptions } from "@rsbuild/plugin-react";
 import { pluginSvgr, type PluginSvgrOptions } from "@rsbuild/plugin-svgr";
-import { SwcJsMinimizerRspackPlugin, type Optimization } from "@rspack/core";
+import type { Optimization } from "@rspack/core";
 import path from "node:path";
 import { applyTransformers, type RsbuildConfigTransformer } from "./applyTransformers.ts";
 
@@ -24,6 +24,8 @@ export interface DefineBuildConfigOptions {
     minify?: Minify;
     optimize?: OptimizeOption;
     sourceMap?: boolean | SourceMap;
+    polyfill?: Polyfill;
+    splitChunks?: SplitChunksConfig | false;
     react?: false | DefineBuildDefineReactPluginConfigFunction;
     svgr?: false | DefineBuildSvgrPluginConfigFunction;
     compressImage?: false | DefineBuildImageCompressPluginConfigFunction;
@@ -48,40 +50,49 @@ function defineImageCompressPluginConfig(options: PluginImageCompressOptions) {
     return options;
 }
 
-export function getOptimizationConfig(optimize: OptimizeOption): Optimization {
-    if (optimize === true) {
+export function getMinifyConfig(optimize: OptimizeOption, minify: Minify): Minify {
+    if (optimize === false) {
+        return false;
+    }
+
+    if (optimize === "readable") {
         return {
-            minimize: true
-        };
-    } else if (optimize === "readable") {
-        return {
-            minimize: true,
-            minimizer: [
-                new SwcJsMinimizerRspackPlugin({
-                    minimizerOptions: {
-                        mangle: false,
-                        compress: {
-                            toplevel: true,
-                            hoist_props: false
-                        }
+            jsOptions: {
+                minimizerOptions: {
+                    mangle: false,
+                    compress: {
+                        toplevel: true,
+                        hoist_props: false
                     }
-                })
-            ],
+                }
+            }
+        };
+    }
+
+    return minify;
+}
+
+export function getOptimizationConfig(optimize: OptimizeOption): Optimization | undefined {
+    if (optimize === "readable") {
+        return {
             chunkIds: "named",
             moduleIds: "named",
             mangleExports: false
         };
     }
 
-    // Doesn't turnoff everything but is good enough to help with debugging scenarios.
-    return {
-        minimize: false,
-        chunkIds: "named",
-        moduleIds: "named",
-        concatenateModules: false,
-        mangleExports: false,
-        usedExports: false
-    };
+    if (optimize === false) {
+        // Doesn't turnoff everything but is good enough to help with debugging scenarios.
+        return {
+            chunkIds: "named",
+            moduleIds: "named",
+            concatenateModules: false,
+            mangleExports: false,
+            usedExports: false
+        };
+    }
+
+    return undefined;
 }
 
 export function defineBuildConfig(options: DefineBuildConfigOptions = {}) {
@@ -101,6 +112,11 @@ export function defineBuildConfig(options: DefineBuildConfigOptions = {}) {
             js: "source-map",
             css: true
         },
+        polyfill = "usage",
+        splitChunks = {
+            preset: "per-package",
+            chunks: "all"
+        } satisfies SplitChunksConfig,
         react = defaultDefineReactPluginConfig,
         svgr = defineSvgrPluginConfig,
         compressImage = defineImageCompressPluginConfig,
@@ -131,9 +147,11 @@ export function defineBuildConfig(options: DefineBuildConfigOptions = {}) {
             distPath,
             cleanDistPath: true,
             assetPrefix,
-            minify,
-            sourceMap
+            minify: getMinifyConfig(optimize, minify),
+            sourceMap,
+            polyfill
         },
+        splitChunks,
         html: html
             ? html({ template: path.resolve("./public/index.html") })
             : undefined,

--- a/packages/rsbuild-configs/src/build.ts
+++ b/packages/rsbuild-configs/src/build.ts
@@ -50,7 +50,7 @@ function defineImageCompressPluginConfig(options: PluginImageCompressOptions) {
     return options;
 }
 
-export function getMinifyConfig(optimize: OptimizeOption, minify: Minify): Minify {
+function getMinifyConfig(optimize: OptimizeOption, minify: Minify): Minify {
     if (optimize === false) {
         return false;
     }
@@ -82,7 +82,7 @@ export function getOptimizationConfig(optimize: OptimizeOption): Optimization | 
     }
 
     if (optimize === false) {
-        // Doesn't turnoff everything but is good enough to help with debugging scenarios.
+        // Doesn't turn off everything but is good enough to help with debugging scenarios.
         return {
             chunkIds: "named",
             moduleIds: "named",

--- a/packages/rsbuild-configs/src/dev.ts
+++ b/packages/rsbuild-configs/src/dev.ts
@@ -26,6 +26,7 @@ export interface DefineDevConfigOptions {
     sourceMap?: false | SourceMap;
     overlay?: false;
     writeToDisk?: true;
+    setup?: ServerConfig["setup"];
     react?: false | DefineDevDefineReactPluginConfigFunction;
     svgr?: false | DefineDevSvgrPluginConfigFunction;
     environmentVariables?: Record<string, unknown>;
@@ -65,6 +66,7 @@ export function defineDevConfig(options: DefineDevConfigOptions = {}) {
         },
         overlay,
         writeToDisk,
+        setup,
         react = defaultDefineReactPluginConfig,
         svgr = defineSvgrPluginConfig,
         // Using an empty object literal as the default value to ensure
@@ -89,7 +91,8 @@ export function defineDevConfig(options: DefineDevConfigOptions = {}) {
             https: isBoolean(https) || isFunction(https) ? undefined : https,
             host,
             port,
-            historyApiFallback: true
+            historyApiFallback: true,
+            setup
         },
         source: {
             entry,

--- a/packages/rsbuild-configs/src/storybook.ts
+++ b/packages/rsbuild-configs/src/storybook.ts
@@ -28,7 +28,7 @@ function defineSvgrPluginConfig(options: PluginSvgrOptions) {
 export function defineStorybookConfig(options: DefineStorybookConfigOptions = {}) {
     const {
         plugins = [],
-        lazyCompilation = false,
+        lazyCompilation = true,
         sourceMap = {
             js: "cheap-module-source-map",
             css: true

--- a/packages/rsbuild-configs/tests/build.test.ts
+++ b/packages/rsbuild-configs/tests/build.test.ts
@@ -1,7 +1,7 @@
 import type { DistPathConfig, Minify, RsbuildConfig, RsbuildPlugin, SourceMap, SplitChunksConfig } from "@rsbuild/core";
 import { describe, test, vi } from "vitest";
 import type { RsbuildConfigTransformer } from "../src/applyTransformers.ts";
-import { defineBuildConfig, getMinifyConfig, getOptimizationConfig } from "../src/build.ts";
+import { defineBuildConfig, getOptimizationConfig } from "../src/build.ts";
 
 test.concurrent("when an entry prop is provided, the source.entry option is the provided value", ({ expect }) => {
     const result = defineBuildConfig({
@@ -241,18 +241,18 @@ test.concurrent("when the verbose option is true, the transformers context verbo
     expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "build", verbose: true });
 });
 
-describe("getMinifyConfig", () => {
-    test.concurrent("when optimize is true, return the provided minify value", ({ expect }) => {
-        expect(getMinifyConfig(true, true)).toBe(true);
-        expect(getMinifyConfig(true, false)).toBe(false);
+describe("output.minify", () => {
+    test.concurrent("when optimize is true, output.minify equals the provided minify value", ({ expect }) => {
+        expect(defineBuildConfig({ optimize: true, minify: true }).output?.minify).toBe(true);
+        expect(defineBuildConfig({ optimize: true, minify: false }).output?.minify).toBe(false);
     });
 
-    test.concurrent("when optimize is false, minify is forced to false", ({ expect }) => {
-        expect(getMinifyConfig(false, true)).toBe(false);
+    test.concurrent("when optimize is false, output.minify is forced to false", ({ expect }) => {
+        expect(defineBuildConfig({ optimize: false, minify: true }).output?.minify).toBe(false);
     });
 
-    test.concurrent("when optimize is \"readable\", return SWC options with mangle disabled", ({ expect }) => {
-        const result = getMinifyConfig("readable", true) as Exclude<Minify, boolean>;
+    test.concurrent("when optimize is \"readable\", output.minify configures SWC with mangle disabled", ({ expect }) => {
+        const result = defineBuildConfig({ optimize: "readable" }).output?.minify as Exclude<Minify, boolean>;
 
         expect(result.jsOptions?.minimizerOptions?.mangle).toBe(false);
     });

--- a/packages/rsbuild-configs/tests/build.test.ts
+++ b/packages/rsbuild-configs/tests/build.test.ts
@@ -1,7 +1,7 @@
-import type { DistPathConfig, RsbuildConfig, RsbuildPlugin, SourceMap } from "@rsbuild/core";
+import type { DistPathConfig, Minify, RsbuildConfig, RsbuildPlugin, SourceMap, SplitChunksConfig } from "@rsbuild/core";
 import { describe, test, vi } from "vitest";
 import type { RsbuildConfigTransformer } from "../src/applyTransformers.ts";
-import { defineBuildConfig, getOptimizationConfig } from "../src/build.ts";
+import { defineBuildConfig, getMinifyConfig, getOptimizationConfig } from "../src/build.ts";
 
 test.concurrent("when an entry prop is provided, the source.entry option is the provided value", ({ expect }) => {
     const result = defineBuildConfig({
@@ -241,58 +241,96 @@ test.concurrent("when the verbose option is true, the transformers context verbo
     expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "build", verbose: true });
 });
 
+describe("getMinifyConfig", () => {
+    test.concurrent("when optimize is true, return the provided minify value", ({ expect }) => {
+        expect(getMinifyConfig(true, true)).toBe(true);
+        expect(getMinifyConfig(true, false)).toBe(false);
+    });
+
+    test.concurrent("when optimize is false, minify is forced to false", ({ expect }) => {
+        expect(getMinifyConfig(false, true)).toBe(false);
+    });
+
+    test.concurrent("when optimize is \"readable\", return SWC options with mangle disabled", ({ expect }) => {
+        const result = getMinifyConfig("readable", true) as Exclude<Minify, boolean>;
+
+        expect(result.jsOptions?.minimizerOptions?.mangle).toBe(false);
+    });
+});
+
 describe("getOptimizationConfig", () => {
-    test.concurrent("when optimize is true, minimize is set to true", ({ expect }) => {
-        const result = getOptimizationConfig(true);
-
-        expect(result.minimize).toBeTruthy();
+    test.concurrent("when optimize is true, return undefined to defer to Rsbuild defaults", ({ expect }) => {
+        expect(getOptimizationConfig(true)).toBeUndefined();
     });
 
-    test.concurrent("when optimize is false, minimize is set to false", ({ expect }) => {
+    test.concurrent("when optimize is false, chunkIds and moduleIds are set to \"named\"", ({ expect }) => {
         const result = getOptimizationConfig(false);
 
-        expect(result.minimize).toBeFalsy();
+        expect(result?.chunkIds).toBe("named");
+        expect(result?.moduleIds).toBe("named");
     });
 
-    test.concurrent("when optimize is \"readable\", minimize is set to true", ({ expect }) => {
-        const result = getOptimizationConfig("readable");
-
-        expect(result.minimize).toBeTruthy();
-    });
-
-    test.concurrent("when optimize is false, chunkIds is set to \"named\"", ({ expect }) => {
+    test.concurrent("when optimize is false, concatenateModules and usedExports are disabled", ({ expect }) => {
         const result = getOptimizationConfig(false);
 
-        expect(result.chunkIds).toBe("named");
+        expect(result?.concatenateModules).toBe(false);
+        expect(result?.usedExports).toBe(false);
     });
 
-    test.concurrent("when optimize is false, moduleIds is set to \"named\"", ({ expect }) => {
-        const result = getOptimizationConfig(false);
-
-        expect(result.chunkIds).toBe("named");
-    });
-
-    test.concurrent("when optimize is \"readable\", chunkIds is set to \"named\"", ({ expect }) => {
+    test.concurrent("when optimize is \"readable\", chunkIds and moduleIds are set to \"named\"", ({ expect }) => {
         const result = getOptimizationConfig("readable");
 
-        expect(result.chunkIds).toBe("named");
+        expect(result?.chunkIds).toBe("named");
+        expect(result?.moduleIds).toBe("named");
     });
 
-    test.concurrent("when optimize is \"readable\", moduleIds is set to \"named\"", ({ expect }) => {
+    test.concurrent("when optimize is \"readable\", mangleExports is disabled", ({ expect }) => {
         const result = getOptimizationConfig("readable");
 
-        expect(result.chunkIds).toBe("named");
+        expect(result?.mangleExports).toBe(false);
+    });
+});
+
+test.concurrent("by default, the output.polyfill option is set to \"usage\"", ({ expect }) => {
+    const result = defineBuildConfig();
+
+    expect(result.output?.polyfill).toBe("usage");
+});
+
+test.concurrent("when polyfill is provided, the output.polyfill option is the provided value", ({ expect }) => {
+    const result = defineBuildConfig({
+        polyfill: "off"
     });
 
-    test.concurrent("when optimize is false, do not include minimizer configuration", ({ expect }) => {
-        const result = getOptimizationConfig(false);
+    expect(result.output?.polyfill).toBe("off");
+});
 
-        expect(result.minimizer).toBeUndefined();
+test.concurrent("by default, the splitChunks option uses the \"per-package\" preset", ({ expect }) => {
+    const result = defineBuildConfig();
+
+    const splitChunks = result.splitChunks as SplitChunksConfig;
+
+    expect(splitChunks.preset).toBe("per-package");
+    expect(splitChunks.chunks).toBe("all");
+});
+
+test.concurrent("when splitChunks is provided, the splitChunks option is the provided value", ({ expect }) => {
+    const splitChunks: SplitChunksConfig = {
+        preset: "single-vendor",
+        chunks: "all"
+    };
+
+    const result = defineBuildConfig({
+        splitChunks
     });
 
-    test.concurrent("when optimize is \"readable\", include minify configuration", ({ expect }) => {
-        const result = getOptimizationConfig("readable");
+    expect(result.splitChunks).toBe(splitChunks);
+});
 
-        expect(result.minimizer).toBeDefined();
+test.concurrent("when splitChunks is false, the splitChunks option is false", ({ expect }) => {
+    const result = defineBuildConfig({
+        splitChunks: false
     });
+
+    expect(result.splitChunks).toBe(false);
 });

--- a/packages/rsbuild-configs/tests/dev.test.ts
+++ b/packages/rsbuild-configs/tests/dev.test.ts
@@ -337,3 +337,13 @@ test.concurrent("when the verbose option is true, the transformers context verbo
     expect(mockTransformer).toHaveBeenCalledWith(expect.anything(), { environment: "dev", verbose: true });
 });
 
+test.concurrent("when setup is provided, the server.setup option is the provided value", ({ expect }) => {
+    const setup = vi.fn();
+
+    const result = defineDevConfig({
+        setup
+    });
+
+    expect(result.server?.setup).toBe(setup);
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,10 +146,10 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/eslint-plugin-jsx-a11y':
         specifier: 6.10.1
         version: 6.10.1(jiti@2.7.0)
@@ -192,7 +192,7 @@ importers:
         version: 9.39.2
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -228,26 +228,29 @@ importers:
     dependencies:
       '@rsbuild/plugin-basic-ssl':
         specifier: ^1.2.2
-        version: 1.2.2(@rsbuild/core@2.0.5)
+        version: 1.2.2(@rsbuild/core@2.0.5(core-js@3.49.0))
       '@rsbuild/plugin-image-compress':
         specifier: ^1.3.3
-        version: 1.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)
+        version: 1.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5(core-js@3.49.0))
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
+      core-js:
+        specifier: ^3.49.0
+        version: 3.49.0
     devDependencies:
       '@eslint/js':
         specifier: 9.39.2
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@rspack/core':
         specifier: 2.0.3
         version: 2.0.3(@swc/helpers@0.5.21)
@@ -286,17 +289,17 @@ importers:
     dependencies:
       '@rsbuild/plugin-react':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+        version: 2.0.0(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
       '@rsbuild/plugin-svgr':
         specifier: ^2.0.2
-        version: 2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
+        version: 2.0.2(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.39.2
         version: 9.39.2
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -391,10 +394,10 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -437,10 +440,10 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -534,10 +537,10 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@svgr/core':
         specifier: 8.1.0
         version: 8.1.0(typescript@6.0.3)
@@ -598,7 +601,7 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rspack/core':
         specifier: 2.0.3
         version: 2.0.3(@swc/helpers@0.5.21)
@@ -689,7 +692,7 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -734,7 +737,7 @@ importers:
         version: 3.8.3
       storybook-react-rsbuild:
         specifier: 3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
+        version: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
       stylelint:
         specifier: 16.26.1
         version: 16.26.1(typescript@6.0.3)
@@ -755,7 +758,7 @@ importers:
         version: 9.39.2
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@types/node':
         specifier: 25.7.0
         version: 25.7.0
@@ -798,7 +801,7 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rspack/core':
         specifier: 2.0.3
         version: 2.0.3(@swc/helpers@0.5.21)
@@ -852,7 +855,7 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       storybook-react-rsbuild:
         specifier: 3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
+        version: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -874,10 +877,10 @@ importers:
         version: 9.39.2
       '@rsbuild/core':
         specifier: 2.0.5
-        version: 2.0.5
+        version: 2.0.5(core-js@3.49.0)
       '@rslib/core':
         specifier: 0.21.4
-        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+        version: 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
       '@storybook/addon-a11y':
         specifier: 10.3.6
         version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -925,10 +928,10 @@ importers:
         version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       storybook-addon-rslib:
         specifier: 3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.5)(@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3))(storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3))(typescript@6.0.3)
+        version: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3))(storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3))(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: 3.3.3
-        version: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
+        version: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -6083,6 +6086,9 @@ packages:
 
   core-js-pure@3.49.0:
     resolution: {integrity: sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -15161,70 +15167,72 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
-  '@rsbuild/core@2.0.5':
+  '@rsbuild/core@2.0.5(core-js@3.49.0)':
     dependencies:
       '@rspack/core': 2.0.3(@swc/helpers@0.5.21)
       '@swc/helpers': 0.5.21
+    optionalDependencies:
+      core-js: 3.49.0
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-basic-ssl@1.2.2(@rsbuild/core@2.0.5)':
+  '@rsbuild/plugin-basic-ssl@1.2.2(@rsbuild/core@2.0.5(core-js@3.49.0))':
     dependencies:
       selfsigned: 3.0.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
 
-  '@rsbuild/plugin-image-compress@1.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5)':
+  '@rsbuild/plugin-image-compress@1.3.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.5(core-js@3.49.0))':
     dependencies:
       '@napi-rs/image': 1.11.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       svgo: 3.3.3
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))':
+  '@rsbuild/plugin-react@2.0.0(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))':
     dependencies:
       '@rspack/plugin-react-refresh': 2.0.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)':
+  '@rsbuild/plugin-svgr@2.0.2(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))
+      '@rsbuild/plugin-react': 2.0.0(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       deepmerge: 4.3.1
       loader-utils: 3.3.1
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.3.0(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)':
+  '@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)':
     dependencies:
-      '@rsbuild/core': 2.0.5
-      rsbuild-plugin-dts: 0.21.4(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
+      rsbuild-plugin-dts: 0.21.4(@rsbuild/core@2.0.5(core-js@3.49.0))(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -17172,6 +17180,8 @@ snapshots:
       browserslist: 4.28.2
 
   core-js-pure@3.49.0: {}
+
+  core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -21926,20 +21936,20 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rsbuild-plugin-dts@0.21.4(@rsbuild/core@2.0.5)(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.4(@rsbuild/core@2.0.5(core-js@3.49.0))(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260512.1
       typescript: 6.0.3
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.5):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.0.5(core-js@3.49.0)):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
 
   run-applescript@7.1.0: {}
 
@@ -22344,18 +22354,18 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-rslib@3.3.3(@rsbuild/core@2.0.5)(@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3))(storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3))(typescript@6.0.3):
+  storybook-addon-rslib@3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rslib/core@0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3))(storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.5
-      '@rslib/core': 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(typescript@6.0.3)
-      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
+      '@rslib/core': 0.21.4(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3):
+  storybook-builder-rsbuild@3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.0.5
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(tslib@2.8.1)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -22367,7 +22377,7 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.5)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.0.5(core-js@3.49.0))
       sirv: 2.0.4
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       ts-dedent: 2.2.0
@@ -22384,10 +22394,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-react-rsbuild@3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2):
+  storybook-react-rsbuild@3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.3)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)(webpack@5.106.2):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@rsbuild/core': 2.0.5
+      '@rsbuild/core': 2.0.5(core-js@3.49.0)
       '@storybook/react': 10.3.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)(webpack@5.106.2)
       find-up: 5.0.0
@@ -22398,7 +22408,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       resolve: 1.22.12
       storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5)(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)
+      storybook-builder-rsbuild: 3.3.3(@rsbuild/core@2.0.5(core-js@3.49.0))(@rspack/core@2.0.3(@swc/helpers@0.5.21))(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(tslib@2.8.1)(typescript@6.0.3)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3


### PR DESCRIPTION
- Updated package configurations and API to align with new Rsbuild 2.0 features, improvements, and deprecations.
- Added new options: `polyfill`, `splitChunks`, and `setup` to `defineBuildConfig` and `defineDevConfig`.
- Introduced migration documentation for Rsbuild v2.0 and Rslib v2.0, detailing package updates, Node.js requirements, and changed defaults.
- Refactored internal optimization configuration to use Rsbuild's new output structure.