### PR TITLE
feat: enable erasableSyntaxOnly in TypeScript configs

### DIFF
--- a/.changeset/brave-tigers-erase.md
+++ b/.changeset/brave-tigers-erase.md
@@ -1,0 +1,9 @@
+---
+"@workleap/typescript-configs": major
+---
+
+Enable `erasableSyntaxOnly` in the core TypeScript config.
+
+TypeScript syntax that compiles to runtime code is now a type error: `enum`, constructor parameter properties, value `namespace`s, and `import =` aliases. This keeps the codebase compatible with type-stripping runtimes (Node `--experimental-strip-types`) and erasure-only toolchains.
+
+This is a breaking change for consumers using any of those constructs — replace `enum`s with `as const` object literals and constructor parameter properties with explicit field assignments, or set `"erasableSyntaxOnly": false` in your own `tsconfig.json` to opt out.

--- a/packages/browserslist-config/src/index.ts
+++ b/packages/browserslist-config/src/index.ts
@@ -5,7 +5,7 @@ const config: string[] = [
     "not dead"
 ];
 
-// Using TypeScript "export" keyword until browserlist support ESM.
-// Otherwise we must deal with a weird CommonJS output from esbuild which is not worth it.
-// For more info, see: https://github.com/evanw/esbuild/issues/1079
+// Using TypeScript "export =" until browserslist supports ESM configs.
+// It's the only syntax emitting `module.exports = config`, which browserslist
+// expects since it loads configs via require().
 export = config;

--- a/packages/browserslist-config/tsconfig.json
+++ b/packages/browserslist-config/tsconfig.json
@@ -3,7 +3,11 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "types": ["node"]
+        "types": ["node"],
+        // This package must use `export =` so the emitted CJS sets `module.exports` to the
+        // config object itself, as browserslist loads configs via require() and doesn't
+        // support ESM configs.
+        "erasableSyntaxOnly": false
     },
     "exclude": ["dist", "node_modules"]
 }

--- a/packages/stylelint-configs/src/index.ts
+++ b/packages/stylelint-configs/src/index.ts
@@ -75,7 +75,7 @@ const config: Config = {
     }
 };
 
-// Using TypeScript "export" keyword until StyleLint support ESM.
-// Otherwise we must deal with a weird CommonJS output from esbuild which is not worth it.
-// For more info, see: https://github.com/evanw/esbuild/issues/1079
+// Using TypeScript "export =" until Stylelint supports ESM configs.
+// It's the only syntax emitting `module.exports = config`, which Stylelint
+// expects since it loads configs via require().
 export = config;

--- a/packages/stylelint-configs/tsconfig.json
+++ b/packages/stylelint-configs/tsconfig.json
@@ -3,7 +3,11 @@
     "compilerOptions": {
         "incremental": true,
         "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
-        "types": ["node"]
+        "types": ["node"],
+        // This package must use `export =` so the emitted CJS sets `module.exports` to the
+        // config object itself, as Stylelint loads configs via require() and doesn't
+        // support ESM configs.
+        "erasableSyntaxOnly": false
     },
     "exclude": ["dist", "node_modules"]
 }

--- a/packages/typescript-configs/core.json
+++ b/packages/typescript-configs/core.json
@@ -9,6 +9,7 @@
         "types": ["node"],
 
         "isolatedModules": true,
+        "erasableSyntaxOnly": true,
         "allowSyntheticDefaultImports": true,
         "resolveJsonModule": true,
 


### PR DESCRIPTION
## What

Adds `"erasableSyntaxOnly": true` to `packages/typescript-configs/core.json` — all variants (`react`, `library`, `web-application`, `monorepo-workspace`) inherit it.

## Why

Bans TypeScript syntax that compiles to runtime code: `enum`, constructor parameter properties, value `namespace`s, `import =` aliases. Keeps consumers compatible with type-stripping runtimes (Node `--experimental-strip-types`) and erasure-only toolchains, and removes a class of TS-only runtime semantics. Already the working convention in wl-app — this gives it compiler enforcement org-wide.

## Breaking change

Consumers using `enum` / parameter properties / value namespaces / `import =` will get type errors on upgrade — hence the **major** changeset (happy to downgrade to minor if you'd rather treat it as a lint-tightening). Opt-out is one line in the consumer's `tsconfig.json`: `"erasableSyntaxOnly": false`.

## Verification

- Flag requires TS ≥ 5.8; this package's peer range is `typescript ^6.0.3` — no peer bump needed.
- Validated against the wl-app monorepo: 32/32 workspaces typecheck cleanly (`tsgo`) with the flag enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)